### PR TITLE
Implement save system with autosave

### DIFF
--- a/Assets/_Project/Scripts/System/Game.cs
+++ b/Assets/_Project/Scripts/System/Game.cs
@@ -1,8 +1,125 @@
+using System.Collections;
 using UnityEngine;
 
 namespace GoldenWrap.Systems
 {
     public sealed class Game : MonoBehaviour
     {
+        private const float AutoSaveIntervalSeconds = 60f;
+
+        private static readonly WaitForSeconds AutoSaveDelay = new WaitForSeconds(AutoSaveIntervalSeconds);
+        private static readonly Rect AddCreditsButtonRect = new Rect(10f, 10f, 160f, 32f);
+        private static readonly Rect WipeButtonRect = new Rect(10f, 52f, 160f, 32f);
+
+        private SaveData _saveData;
+        private Coroutine _autoSaveCoroutine;
+
+        private void Awake()
+        {
+            LoadSaveData();
+            EnsureSaveKeyExists();
+        }
+
+        private void OnEnable()
+        {
+            StartAutoSave();
+        }
+
+        private void StartAutoSave()
+        {
+            if (_autoSaveCoroutine == null)
+            {
+                _autoSaveCoroutine = StartCoroutine(AutoSaveRoutine());
+            }
+        }
+
+        private void StopAutoSave()
+        {
+            if (_autoSaveCoroutine != null)
+            {
+                StopCoroutine(_autoSaveCoroutine);
+                _autoSaveCoroutine = null;
+            }
+        }
+
+        private IEnumerator AutoSaveRoutine()
+        {
+            while (true)
+            {
+                yield return AutoSaveDelay;
+                SaveCurrentState();
+            }
+        }
+
+        private void LoadSaveData()
+        {
+            _saveData = SaveSystem.Load();
+            if (_saveData == null)
+            {
+                _saveData = new SaveData();
+            }
+        }
+
+        private void EnsureSaveKeyExists()
+        {
+            if (!PlayerPrefs.HasKey(SaveSystem.Key))
+            {
+                SaveCurrentState();
+            }
+        }
+
+        private void SaveCurrentState()
+        {
+            if (_saveData == null)
+            {
+                _saveData = new SaveData();
+            }
+
+            SaveSystem.Save(_saveData);
+        }
+
+        private void OnDisable()
+        {
+            StopAutoSave();
+            SaveCurrentState();
+        }
+
+        private void OnApplicationQuit()
+        {
+            SaveCurrentState();
+        }
+
+        private void OnGUI()
+        {
+            if (GUI.Button(AddCreditsButtonRect, "+100 credits"))
+            {
+                AddCredits(100);
+                SaveCurrentState();
+            }
+
+            if (GUI.Button(WipeButtonRect, "Wipe Save"))
+            {
+                WipeSave();
+            }
+        }
+
+        private void AddCredits(int amount)
+        {
+            if (_saveData == null)
+            {
+                _saveData = new SaveData();
+            }
+
+            _saveData.credits += amount;
+        }
+
+        private void WipeSave()
+        {
+            StopAutoSave();
+            SaveSystem.Wipe();
+            _saveData = new SaveData();
+            SaveCurrentState();
+            StartAutoSave();
+        }
     }
 }

--- a/Assets/_Project/Scripts/System/SaveData.cs
+++ b/Assets/_Project/Scripts/System/SaveData.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+namespace GoldenWrap.Systems
+{
+    [Serializable]
+    public sealed class SaveData
+    {
+        public int credits;
+        public int bestCombo;
+        public List<string> unlockedPatterns;
+        public SettingsData settings;
+
+        public SaveData()
+        {
+            credits = 0;
+            bestCombo = 0;
+            unlockedPatterns = new List<string>();
+            settings = null;
+        }
+    }
+
+    [Serializable]
+    public sealed class SettingsData
+    {
+    }
+}

--- a/Assets/_Project/Scripts/System/SaveData.cs.meta
+++ b/Assets/_Project/Scripts/System/SaveData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 23db030a59f34715993e51a369a9eaa2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/_Project/Scripts/System/SaveSystem.cs
+++ b/Assets/_Project/Scripts/System/SaveSystem.cs
@@ -1,0 +1,63 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GoldenWrap.Systems
+{
+    public static class SaveSystem
+    {
+        public const string Key = "GW_Save_v1";
+
+        public static void Save(SaveData data)
+        {
+            if (data == null)
+            {
+                data = new SaveData();
+            }
+
+            if (data.unlockedPatterns == null)
+            {
+                data.unlockedPatterns = new List<string>();
+            }
+
+            var json = JsonUtility.ToJson(data);
+            PlayerPrefs.SetString(Key, json);
+            PlayerPrefs.Save();
+        }
+
+        public static SaveData Load()
+        {
+            if (!PlayerPrefs.HasKey(Key))
+            {
+                return new SaveData();
+            }
+
+            var json = PlayerPrefs.GetString(Key);
+            if (string.IsNullOrEmpty(json))
+            {
+                return new SaveData();
+            }
+
+            var data = JsonUtility.FromJson<SaveData>(json);
+            if (data == null)
+            {
+                data = new SaveData();
+            }
+
+            if (data.unlockedPatterns == null)
+            {
+                data.unlockedPatterns = new List<string>();
+            }
+
+            return data;
+        }
+
+        public static void Wipe()
+        {
+            if (PlayerPrefs.HasKey(Key))
+            {
+                PlayerPrefs.DeleteKey(Key);
+                PlayerPrefs.Save();
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/System/SaveSystem.cs.meta
+++ b/Assets/_Project/Scripts/System/SaveSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a29d45dd57474c2f8a2467af64a4ca97
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add serializable save and settings data classes for game persistence
- implement a PlayerPrefs-backed save system using JsonUtility
- extend the Game component with autosave, load/save hooks, and temporary debug buttons

## Testing
- not run (Unity editor only)


------
https://chatgpt.com/codex/tasks/task_e_68d857670aa483228d4fc797092f277d