### PR TITLE
Add conveyor line pooling system

### DIFF
--- a/Assets/_Project/Prefabs/Candy.prefab
+++ b/Assets/_Project/Prefabs/Candy.prefab
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &8233245259707707491
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8233245259707707492}
+  - component: {fileID: 8233245259707707493}
+  m_Layer: 0
+  m_Name: Candy
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8233245259707707492
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8233245259707707491}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &8233245259707707493
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8233245259707707491}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 0.9490197, g: 0.43137258, b: 0.10196079, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/_Project/Prefabs/Candy.prefab.meta
+++ b/Assets/_Project/Prefabs/Candy.prefab.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: 3d5d3b314c0342a3a7c8f8977a0c9e2f
-folderAsset: yes
-DefaultImporter:
+guid: 5a2a4c5bf0b5d4c44a3a4e3ca5f7a1c1
+PrefabImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Assets/_Project/Prefabs/FoilBlank.prefab
+++ b/Assets/_Project/Prefabs/FoilBlank.prefab
@@ -1,0 +1,85 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4012082074982748201
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4012082074982748202}
+  - component: {fileID: 4012082074982748203}
+  m_Layer: 0
+  m_Name: FoilBlank
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4012082074982748202
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012082074982748201}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &4012082074982748203
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4012082074982748201}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 0.79215693, g: 0.80392164, b: 0.85098046, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/_Project/Prefabs/FoilBlank.prefab.meta
+++ b/Assets/_Project/Prefabs/FoilBlank.prefab.meta
@@ -1,7 +1,6 @@
 fileFormatVersion: 2
-guid: 3d5d3b314c0342a3a7c8f8977a0c9e2f
-folderAsset: yes
-DefaultImporter:
+guid: 2b5f7a828c16493d88f646a47af180ad
+PrefabImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Assets/_Project/Scripts/Game.meta
+++ b/Assets/_Project/Scripts/Game.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3d5d3b314c0342a3a7c8f8977a0c9e2f
+guid: ddb306f65f6449d2864a5654c97deed9
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/Assets/_Project/Scripts/Game/ConveyorLine.cs
+++ b/Assets/_Project/Scripts/Game/ConveyorLine.cs
@@ -1,0 +1,196 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GoldenWrap.Game
+{
+    public sealed class ConveyorLine : MonoBehaviour
+    {
+        [SerializeField] private LineId lineId = LineId.A;
+        [SerializeField] private float speed = 1.0f;
+        [SerializeField] private float spawnInterval = 1.0f;
+        [SerializeField] private Transform spawnPoint;
+        [SerializeField] private Transform despawnX;
+        [SerializeField] private GameObject prefabCandy;
+        [SerializeField] private GameObject prefabFoil;
+
+        private readonly List<Slot> activeSlots = new List<Slot>(16);
+        private readonly Stack<Transform> candyPool = new Stack<Transform>();
+        private readonly Stack<Transform> foilPool = new Stack<Transform>();
+        private readonly Stack<Transform> slotRootPool = new Stack<Transform>();
+
+        private float spawnTimer;
+        private float despawnBoundaryX;
+        private string slotName;
+
+        public LineId LineId => lineId;
+
+        private void Awake()
+        {
+            slotName = lineId.ToString() + "_Slot";
+            if (despawnX != null)
+            {
+                despawnBoundaryX = despawnX.position.x;
+            }
+            else
+            {
+                despawnBoundaryX = float.PositiveInfinity;
+            }
+        }
+
+        private void OnEnable()
+        {
+            spawnTimer = 0f;
+        }
+
+        private void Update()
+        {
+            var deltaTime = Time.deltaTime;
+            if (spawnInterval > 0f)
+            {
+                spawnTimer += deltaTime;
+                while (spawnTimer >= spawnInterval)
+                {
+                    spawnTimer -= spawnInterval;
+                    SpawnSlot();
+                }
+            }
+
+            if (despawnX != null)
+            {
+                despawnBoundaryX = despawnX.position.x;
+            }
+
+            var movement = speed * deltaTime;
+            for (var i = 0; i < activeSlots.Count; i++)
+            {
+                var slot = activeSlots[i];
+                var root = slot.Root;
+                var position = root.position;
+                position.x += movement;
+                root.position = position;
+
+                if (position.x > despawnBoundaryX)
+                {
+                    DespawnSlot(i);
+                    i--;
+                }
+            }
+        }
+
+        public void SetSpeed(float newSpeed)
+        {
+            speed = newSpeed;
+        }
+
+        private void SpawnSlot()
+        {
+            if (spawnPoint == null || prefabCandy == null || prefabFoil == null)
+            {
+                return;
+            }
+
+            if (despawnX != null)
+            {
+                despawnBoundaryX = despawnX.position.x;
+            }
+
+            var slotRoot = AcquireSlotRoot();
+            var rootPosition = spawnPoint.position;
+            slotRoot.position = rootPosition;
+
+            var candy = AcquireCandy();
+            candy.SetParent(slotRoot, false);
+            candy.localPosition = Vector3.zero;
+
+            var foil = AcquireFoil();
+            foil.SetParent(slotRoot, false);
+            foil.localPosition = Vector3.zero;
+
+            activeSlots.Add(new Slot(slotRoot, candy, foil));
+        }
+
+        private Transform AcquireSlotRoot()
+        {
+            Transform root;
+            if (slotRootPool.Count > 0)
+            {
+                root = slotRootPool.Pop();
+                root.gameObject.SetActive(true);
+            }
+            else
+            {
+                var go = new GameObject(slotName);
+                root = go.transform;
+            }
+
+            root.SetParent(transform, false);
+            return root;
+        }
+
+        private Transform AcquireCandy()
+        {
+            Transform candy;
+            if (candyPool.Count > 0)
+            {
+                candy = candyPool.Pop();
+                candy.gameObject.SetActive(true);
+            }
+            else
+            {
+                candy = Instantiate(prefabCandy).transform;
+            }
+
+            return candy;
+        }
+
+        private Transform AcquireFoil()
+        {
+            Transform foil;
+            if (foilPool.Count > 0)
+            {
+                foil = foilPool.Pop();
+                foil.gameObject.SetActive(true);
+            }
+            else
+            {
+                foil = Instantiate(prefabFoil).transform;
+            }
+
+            return foil;
+        }
+
+        private void DespawnSlot(int index)
+        {
+            var slot = activeSlots[index];
+            activeSlots.RemoveAt(index);
+
+            ReleaseToPool(slot.Candy, candyPool);
+            ReleaseToPool(slot.Foil, foilPool);
+
+            slot.Root.SetParent(transform, false);
+            slot.Root.gameObject.SetActive(false);
+            slotRootPool.Push(slot.Root);
+        }
+
+        private void ReleaseToPool(Transform item, Stack<Transform> pool)
+        {
+            item.SetParent(transform, false);
+            item.gameObject.SetActive(false);
+            pool.Push(item);
+        }
+
+        private readonly struct Slot
+        {
+            public readonly Transform Root;
+            public readonly Transform Candy;
+            public readonly Transform Foil;
+
+            public Slot(Transform root, Transform candy, Transform foil)
+            {
+                Root = root;
+                Candy = candy;
+                Foil = foil;
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Game/ConveyorLine.cs.meta
+++ b/Assets/_Project/Scripts/Game/ConveyorLine.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7b844d2fd8f3469d8e47f4af9286556d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  defineConstraints: []

--- a/Assets/_Project/Scripts/Game/ConveyorManager.cs
+++ b/Assets/_Project/Scripts/Game/ConveyorManager.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using GoldenWrap.Settings;
+using UnityEngine;
+
+namespace GoldenWrap.Game
+{
+    public sealed class ConveyorManager : MonoBehaviour
+    {
+        [SerializeField] private List<ConveyorLine> lines = new List<ConveyorLine>();
+
+        public void Init(GameConfig config)
+        {
+            if (config == null)
+            {
+                return;
+            }
+
+            var speed = config.InitialConveyorSpeed;
+            for (var i = 0; i < lines.Count; i++)
+            {
+                var line = lines[i];
+                if (line != null)
+                {
+                    line.SetSpeed(speed);
+                }
+            }
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Game/ConveyorManager.cs.meta
+++ b/Assets/_Project/Scripts/Game/ConveyorManager.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e645f4f68f4f4e1aa0df767f4f47497a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  defineConstraints: []

--- a/Assets/_Project/Scripts/Game/LineId.cs
+++ b/Assets/_Project/Scripts/Game/LineId.cs
@@ -1,0 +1,9 @@
+namespace GoldenWrap.Game
+{
+    public enum LineId
+    {
+        A,
+        B,
+        C
+    }
+}

--- a/Assets/_Project/Scripts/Game/LineId.cs.meta
+++ b/Assets/_Project/Scripts/Game/LineId.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1e8f10b8b68e4c6d9f3d6dfe94c58ed8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  defineConstraints: []


### PR DESCRIPTION
## Summary
- add conveyor line behaviour that pools candy and foil instances while advancing slots across the belt
- expose a conveyor manager to initialize line speeds from the game configuration
- provide placeholder candy and foil prefabs for spawning on the conveyor

## Testing
- not run (Unity Editor required)


------
https://chatgpt.com/codex/tasks/task_e_68d8584fa72c8322923dd13717d4f45e