### PR TITLE
Implement conveyor line gameplay systems

### DIFF
--- a/Assets/GW/Scripts/Core/GameEnums.cs
+++ b/Assets/GW/Scripts/Core/GameEnums.cs
@@ -1,0 +1,16 @@
+namespace GW.Core
+{
+    public enum GameMode
+    {
+        Career,
+        Zen,
+        MultiPlus,
+    }
+
+    public enum SealGrade
+    {
+        Fail,
+        Good,
+        Perfect,
+    }
+}

--- a/Assets/GW/Scripts/Core/GameEnums.cs.meta
+++ b/Assets/GW/Scripts/Core/GameEnums.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 295555bf5798450ea73eb4dc5a8f067d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Scripts/Gameplay/CandyActor.cs
+++ b/Assets/GW/Scripts/Gameplay/CandyActor.cs
@@ -1,0 +1,44 @@
+using System;
+using UnityEngine;
+
+namespace GW.Gameplay
+{
+    [DisallowMultipleComponent]
+    public sealed class CandyActor : MonoBehaviour
+    {
+        public event Action<CandyActor> Despawned;
+
+        public bool IsActive => isActiveAndEnabled;
+
+        private ConveyorLineController owner;
+        private Vector3 direction;
+        private float speed;
+
+        public void Activate(ConveyorLineController line, Vector3 spawnPosition, Vector3 direction, float speed)
+        {
+            owner = line;
+            this.direction = direction;
+            this.speed = speed;
+
+            transform.position = spawnPosition;
+            gameObject.SetActive(true);
+        }
+
+        public void Tick(float deltaTime)
+        {
+            transform.position += direction * speed * deltaTime;
+        }
+
+        public void SetSpeed(float value)
+        {
+            speed = Mathf.Max(0f, value);
+        }
+
+        public void Despawn()
+        {
+            gameObject.SetActive(false);
+            owner = null;
+            Despawned?.Invoke(this);
+        }
+    }
+}

--- a/Assets/GW/Scripts/Gameplay/CandyActor.cs.meta
+++ b/Assets/GW/Scripts/Gameplay/CandyActor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1984d99a3f9f4cb695fdff7f1f873039
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Scripts/Gameplay/ConveyorLineController.cs
+++ b/Assets/GW/Scripts/Gameplay/ConveyorLineController.cs
@@ -1,0 +1,230 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using GW.Core;
+
+namespace GW.Gameplay
+{
+    [DisallowMultipleComponent]
+    public sealed class ConveyorLineController : MonoBehaviour
+    {
+        [Header("Belt Setup")]
+        [SerializeField]
+        private CandyActor candyPrefab;
+
+        [SerializeField]
+        private Transform spawnPoint;
+
+        [SerializeField]
+        private Transform sealPoint;
+
+        [SerializeField]
+        private Transform despawnPoint;
+
+        [SerializeField]
+        private float spawnInterval = 1.2f;
+
+        [SerializeField]
+        [Range(0.25f, 3f)]
+        private float beltSpeed = 1f;
+
+        [Header("Judge Settings")]
+        [SerializeField]
+        private float perfectWindow = 0.05f;
+
+        [SerializeField]
+        private float goodWindow = 0.12f;
+
+        [SerializeField]
+        private int comboStep = 10;
+
+        [SerializeField]
+        private int maxMultiplierLevel = 4;
+
+        [SerializeField]
+        private SealZone sealZone;
+
+        public event Action<int> ScoreChanged;
+        public event Action<int> ComboChanged;
+        public event Action<int> MultiplierChanged;
+        public event Action<float> BlissChanged;
+        public event Action<SealGrade> SealResolved;
+
+        public int Score => score;
+        public SealJudge Judge => judge;
+        public Vector3 Forward => forwardDirection;
+        public Transform SealPoint => sealPoint;
+
+        private readonly List<CandyActor> activeCandies = new();
+        private readonly Queue<CandyActor> pool = new();
+        private SealJudge judge;
+        private float spawnTimer;
+        private Vector3 forwardDirection = Vector3.right;
+        private float pathLength;
+        private int score;
+
+        private void Awake()
+        {
+            if (spawnPoint == null || sealPoint == null || despawnPoint == null)
+            {
+                Debug.LogError("ConveyorLineController requires spawn, seal, and despawn points configured.", this);
+            }
+
+            forwardDirection = (despawnPoint.position - spawnPoint.position).normalized;
+            pathLength = Vector3.Distance(spawnPoint.position, despawnPoint.position);
+
+            judge = new SealJudge(perfectWindow, goodWindow, comboStep, maxMultiplierLevel);
+            judge.OnScored += HandleScored;
+            judge.OnStateChanged += HandleJudgeStateChanged;
+        }
+
+        private void OnEnable()
+        {
+            if (sealZone != null)
+            {
+                sealZone.BindLine(this);
+            }
+        }
+
+        private void OnDisable()
+        {
+            if (sealZone != null)
+            {
+                sealZone.UnbindLine(this);
+            }
+        }
+
+        private void Update()
+        {
+            TickSpawn(Time.deltaTime);
+            TickCandies(Time.deltaTime);
+        }
+
+        private void TickSpawn(float deltaTime)
+        {
+            if (candyPrefab == null)
+            {
+                return;
+            }
+
+            spawnTimer += deltaTime;
+            if (spawnTimer < spawnInterval)
+            {
+                return;
+            }
+
+            spawnTimer = 0f;
+            SpawnCandy();
+        }
+
+        private void TickCandies(float deltaTime)
+        {
+            if (activeCandies.Count == 0)
+            {
+                return;
+            }
+
+            for (var i = activeCandies.Count - 1; i >= 0; i--)
+            {
+                var candy = activeCandies[i];
+                if (candy == null || !candy.IsActive)
+                {
+                    activeCandies.RemoveAt(i);
+                    continue;
+                }
+
+                candy.Tick(deltaTime);
+
+                var distanceTravelled = Vector3.Dot(candy.transform.position - spawnPoint.position, forwardDirection);
+                if (distanceTravelled > pathLength + 0.1f)
+                {
+                    RecycleCandy(candy);
+                    activeCandies.RemoveAt(i);
+                }
+            }
+        }
+
+        private void SpawnCandy()
+        {
+            var candy = GetOrCreateCandy();
+            candy.SetSpeed(beltSpeed);
+            candy.Activate(this, spawnPoint.position, forwardDirection, beltSpeed);
+            activeCandies.Add(candy);
+        }
+
+        private CandyActor GetOrCreateCandy()
+        {
+            CandyActor candy;
+            if (pool.Count > 0)
+            {
+                candy = pool.Dequeue();
+            }
+            else
+            {
+                candy = Instantiate(candyPrefab, spawnPoint.position, Quaternion.identity, transform);
+            }
+
+            candy.Despawned -= HandleCandyDespawned;
+            candy.Despawned += HandleCandyDespawned;
+            return candy;
+        }
+
+        private void HandleCandyDespawned(CandyActor candy)
+        {
+            if (!pool.Contains(candy))
+            {
+                pool.Enqueue(candy);
+            }
+        }
+
+        private void RecycleCandy(CandyActor candy)
+        {
+            candy.Despawn();
+        }
+
+        internal void ProcessSealAttempt(CandyActor candy, float offset)
+        {
+            if (candy == null || !activeCandies.Contains(candy))
+            {
+                return;
+            }
+
+            var grade = judge.OnSeal(Mathf.Abs(offset));
+            SealResolved?.Invoke(grade);
+
+            activeCandies.Remove(candy);
+            RecycleCandy(candy);
+        }
+
+        internal float CalculateOffsetFromSealPoint(Vector3 worldPosition)
+        {
+            if (sealPoint == null)
+            {
+                return 0f;
+            }
+
+            var delta = worldPosition - sealPoint.position;
+            return Vector3.Dot(delta, forwardDirection);
+        }
+
+        private void HandleScored(int delta, SealGrade grade)
+        {
+            score = Mathf.Max(0, score + delta);
+            ScoreChanged?.Invoke(score);
+        }
+
+        private void HandleJudgeStateChanged()
+        {
+            ComboChanged?.Invoke(judge.Combo);
+            MultiplierChanged?.Invoke(judge.MultiplierLevel);
+            BlissChanged?.Invoke(judge.Bliss);
+        }
+
+        public void ForceReset()
+        {
+            score = 0;
+            ScoreChanged?.Invoke(score);
+            judge.Reset();
+        }
+    }
+}

--- a/Assets/GW/Scripts/Gameplay/ConveyorLineController.cs.meta
+++ b/Assets/GW/Scripts/Gameplay/ConveyorLineController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 88e4eca4ab60447b94e90a82bec68901
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Scripts/Gameplay/SealJudge.cs
+++ b/Assets/GW/Scripts/Gameplay/SealJudge.cs
@@ -1,0 +1,119 @@
+using System;
+using UnityEngine;
+using GW.Core;
+
+namespace GW.Gameplay
+{
+    /// <summary>
+    /// Evaluates seal attempts and maintains combo, multiplier, and bliss state for a conveyor line.
+    /// </summary>
+    [Serializable]
+    public sealed class SealJudge
+    {
+        public int Combo { get; private set; }
+        public int MultiplierLevel { get; private set; }
+        public float Bliss { get; private set; }
+
+        public event Action<int, SealGrade> OnScored;
+        public event Action OnStateChanged;
+
+        private readonly float perfectWindow;
+        private readonly float goodWindow;
+        private readonly int comboStep;
+        private readonly int maxMultiplierLevel;
+        private readonly float multiplierStep;
+        private readonly float blissPerfect;
+        private readonly float blissGood;
+        private readonly float blissFailPenalty;
+        private readonly int failPenalty;
+
+        public SealJudge(
+            float perfectWindow,
+            float goodWindow,
+            int comboStep = 10,
+            int maxMultiplierLevel = 4,
+            float multiplierStep = 0.5f,
+            float blissPerfect = 0.08f,
+            float blissGood = 0.02f,
+            float blissFailPenalty = 0.15f,
+            int failPenalty = 5)
+        {
+            this.perfectWindow = Mathf.Max(0.0001f, perfectWindow);
+            this.goodWindow = Mathf.Max(this.perfectWindow, goodWindow);
+            this.comboStep = Mathf.Max(1, comboStep);
+            this.maxMultiplierLevel = Mathf.Max(0, maxMultiplierLevel);
+            this.multiplierStep = Mathf.Max(0f, multiplierStep);
+            this.blissPerfect = Mathf.Max(0f, blissPerfect);
+            this.blissGood = Mathf.Max(0f, blissGood);
+            this.blissFailPenalty = Mathf.Max(0f, blissFailPenalty);
+            this.failPenalty = Mathf.Max(0, failPenalty);
+        }
+
+        public SealGrade OnSeal(float offsetAbs)
+        {
+            SealGrade grade;
+
+            if (offsetAbs <= perfectWindow)
+            {
+                grade = SealGrade.Perfect;
+                Combo++;
+                Bliss = Mathf.Clamp01(Bliss + blissPerfect);
+
+                if (Combo % comboStep == 0)
+                {
+                    MultiplierLevel = Mathf.Min(MultiplierLevel + 1, maxMultiplierLevel);
+                }
+            }
+            else if (offsetAbs <= goodWindow)
+            {
+                grade = SealGrade.Good;
+                Combo = Mathf.Max(1, Combo);
+                Bliss = Mathf.Clamp01(Bliss + blissGood);
+            }
+            else
+            {
+                grade = SealGrade.Fail;
+                Combo = 0;
+                MultiplierLevel = Mathf.Max(0, MultiplierLevel - 1);
+                Bliss = Mathf.Clamp01(Bliss - blissFailPenalty);
+            }
+
+            var deltaScore = CalculateScoreDelta(grade);
+
+            if (grade == SealGrade.Fail)
+            {
+                deltaScore = -failPenalty;
+            }
+
+            OnScored?.Invoke(deltaScore, grade);
+            OnStateChanged?.Invoke();
+            return grade;
+        }
+
+        private int CalculateScoreDelta(SealGrade grade)
+        {
+            float baseValue = grade switch
+            {
+                SealGrade.Perfect => 25f,
+                SealGrade.Good => 10f,
+                _ => 0f,
+            };
+
+            if (baseValue <= 0f)
+            {
+                return 0;
+            }
+
+            var multiplier = 1f + MultiplierLevel * multiplierStep;
+            return Mathf.RoundToInt(baseValue * multiplier);
+        }
+
+        public void Reset()
+        {
+            Combo = 0;
+            MultiplierLevel = 0;
+            Bliss = 0f;
+            OnStateChanged?.Invoke();
+        }
+    }
+}

--- a/Assets/GW/Scripts/Gameplay/SealJudge.cs.meta
+++ b/Assets/GW/Scripts/Gameplay/SealJudge.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dcab7edadb6647b19931f3fc9498d4d9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Scripts/Gameplay/SealZone.cs
+++ b/Assets/GW/Scripts/Gameplay/SealZone.cs
@@ -1,0 +1,146 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+namespace GW.Gameplay
+{
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Collider2D))]
+    public sealed class SealZone : MonoBehaviour
+    {
+        [SerializeField]
+        private ConveyorLineController line;
+
+        private readonly List<CandyActor> candiesInZone = new();
+        private Collider2D triggerCollider;
+
+        private void Awake()
+        {
+            triggerCollider = GetComponent<Collider2D>();
+            if (triggerCollider != null)
+            {
+                triggerCollider.isTrigger = true;
+            }
+
+            if (line != null)
+            {
+                BindLine(line);
+            }
+        }
+
+        private void Update()
+        {
+            if (line == null)
+            {
+                return;
+            }
+
+            if (Input.GetMouseButtonDown(0))
+            {
+                if (EventSystem.current != null && EventSystem.current.IsPointerOverGameObject())
+                {
+                    return;
+                }
+
+                AttemptSeal();
+            }
+        }
+
+        public void BindLine(ConveyorLineController controller)
+        {
+            if (line == controller)
+            {
+                return;
+            }
+
+            if (controller == null)
+            {
+                line = null;
+                candiesInZone.Clear();
+                return;
+            }
+
+            line = controller;
+        }
+
+        public void UnbindLine(ConveyorLineController controller)
+        {
+            if (line != controller)
+            {
+                return;
+            }
+
+            line = null;
+            candiesInZone.Clear();
+        }
+
+        private void AttemptSeal()
+        {
+            CleanupInactive();
+            if (candiesInZone.Count == 0)
+            {
+                return;
+            }
+
+            CandyActor targetCandy = null;
+            var bestOffset = float.MaxValue;
+
+            foreach (var candy in candiesInZone)
+            {
+                if (candy == null || !candy.IsActive)
+                {
+                    continue;
+                }
+
+                var offset = Mathf.Abs(line.CalculateOffsetFromSealPoint(candy.transform.position));
+                if (offset < bestOffset)
+                {
+                    bestOffset = offset;
+                    targetCandy = candy;
+                }
+            }
+
+            if (targetCandy == null)
+            {
+                return;
+            }
+
+            var signedOffset = line.CalculateOffsetFromSealPoint(targetCandy.transform.position);
+            line.ProcessSealAttempt(targetCandy, signedOffset);
+        }
+
+        private void CleanupInactive()
+        {
+            for (var i = candiesInZone.Count - 1; i >= 0; i--)
+            {
+                if (candiesInZone[i] == null || !candiesInZone[i].IsActive)
+                {
+                    candiesInZone.RemoveAt(i);
+                }
+            }
+        }
+
+        private void OnTriggerEnter2D(Collider2D other)
+        {
+            if (!other.TryGetComponent(out CandyActor candy))
+            {
+                return;
+            }
+
+            if (!candiesInZone.Contains(candy))
+            {
+                candiesInZone.Add(candy);
+            }
+        }
+
+        private void OnTriggerExit2D(Collider2D other)
+        {
+            if (!other.TryGetComponent(out CandyActor candy))
+            {
+                return;
+            }
+
+            candiesInZone.Remove(candy);
+        }
+    }
+}

--- a/Assets/GW/Scripts/Gameplay/SealZone.cs.meta
+++ b/Assets/GW/Scripts/Gameplay/SealZone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9b04732f571c491ebe2513abfc056032
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Scripts/UI/HUDRoot.cs
+++ b/Assets/GW/Scripts/UI/HUDRoot.cs
@@ -1,9 +1,127 @@
 using UnityEngine;
+using UnityEngine.UI;
+using GW.Gameplay;
 
 namespace GW.UI
 {
     [DisallowMultipleComponent]
     public sealed class HUDRoot : MonoBehaviour
     {
+        [Header("Bindings")]
+        [SerializeField]
+        private ConveyorLineController trackedLine;
+
+        [SerializeField]
+        private Text scoreText;
+
+        [SerializeField]
+        private Text comboText;
+
+        [SerializeField]
+        private Text multiplierText;
+
+        [SerializeField]
+        private Image blissFillImage;
+
+        [SerializeField]
+        private string scoreFormat = "{0:N0}";
+
+        [SerializeField]
+        private string comboFormat = "COMBO {0}";
+
+        [SerializeField]
+        private string multiplierFormat = "×{0:F1}";
+
+        private ConveyorLineController boundLine;
+
+        private void OnEnable()
+        {
+            if (trackedLine != null)
+            {
+                BindLine(trackedLine);
+            }
+        }
+
+        private void OnDisable()
+        {
+            UnbindLine();
+        }
+
+        public void BindLine(ConveyorLineController line)
+        {
+            if (line == boundLine)
+            {
+                return;
+            }
+
+            UnbindLine();
+            boundLine = line;
+
+            if (boundLine == null)
+            {
+                return;
+            }
+
+            boundLine.ScoreChanged += HandleScoreChanged;
+            boundLine.ComboChanged += HandleComboChanged;
+            boundLine.MultiplierChanged += HandleMultiplierChanged;
+            boundLine.BlissChanged += HandleBlissChanged;
+
+            HandleScoreChanged(boundLine.Score);
+            HandleComboChanged(boundLine.Judge?.Combo ?? 0);
+            HandleMultiplierChanged(boundLine.Judge?.MultiplierLevel ?? 0);
+            HandleBlissChanged(boundLine.Judge?.Bliss ?? 0f);
+        }
+
+        public void UnbindLine()
+        {
+            if (boundLine == null)
+            {
+                return;
+            }
+
+            boundLine.ScoreChanged -= HandleScoreChanged;
+            boundLine.ComboChanged -= HandleComboChanged;
+            boundLine.MultiplierChanged -= HandleMultiplierChanged;
+            boundLine.BlissChanged -= HandleBlissChanged;
+            boundLine = null;
+        }
+
+        private void HandleScoreChanged(int value)
+        {
+            if (scoreText != null)
+            {
+                scoreText.text = string.Format(scoreFormat, value);
+            }
+        }
+
+        private void HandleComboChanged(int combo)
+        {
+            if (comboText != null)
+            {
+                comboText.text = string.Format(comboFormat, Mathf.Max(0, combo));
+            }
+        }
+
+        private void HandleMultiplierChanged(int level)
+        {
+            if (multiplierText == null)
+            {
+                return;
+            }
+
+            var multiplierValue = 1f + level * 0.5f;
+            multiplierText.text = string.Format(multiplierFormat, multiplierValue);
+        }
+
+        private void HandleBlissChanged(float value)
+        {
+            if (blissFillImage == null)
+            {
+                return;
+            }
+
+            blissFillImage.fillAmount = Mathf.Clamp01(value);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add core enums for game modes and seal grades used by gameplay
- implement the conveyor line controller with candy pooling, judging, and scoring logic
- add seal zone and candy actor behaviours and bind the HUD to show score, combo, multiplier, and bliss values

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d86ba17e648322b6914ff5dbbf2725