### PR TITLE
Implement upgrade tree and UI for sprint 5

### DIFF
--- a/Assets/GW/Resources.meta
+++ b/Assets/GW/Resources.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4df81a16811944008d7d44c8cee976c7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Resources/Upgrades.meta
+++ b/Assets/GW/Resources/Upgrades.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7b773787c3d6416cb6cc1a732aaa2a83
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Resources/Upgrades/Acc_GoldenMomentum.asset
+++ b/Assets/GW/Resources/Upgrades/Acc_GoldenMomentum.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5e3d96834e143789b7bcee3a8b11db3, type: 3}
+  m_Name: Acc_GoldenMomentum
+  m_EditorClassIdentifier: 
+  id: acc_golden_momentum
+  title: Golden Momentum
+  description: Raises the combo cap, unlocking a higher multiplier tier.
+  category: 0
+  tier: 2
+  cost: 20
+  prerequisite: {fileID: 11400000, guid: 2ba6cef94aec4852b2dab6626c8701f2, type: 2}
+  effects:
+  - effectType: 3
+    value: 1

--- a/Assets/GW/Resources/Upgrades/Acc_GoldenMomentum.asset.meta
+++ b/Assets/GW/Resources/Upgrades/Acc_GoldenMomentum.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8aeaefd5f08747e489d77db3823a9758
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Resources/Upgrades/Acc_TunedGuides.asset
+++ b/Assets/GW/Resources/Upgrades/Acc_TunedGuides.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5e3d96834e143789b7bcee3a8b11db3, type: 3}
+  m_Name: Acc_TunedGuides
+  m_EditorClassIdentifier: 
+  id: acc_tuned_guides
+  title: Tuned Alignment Rails
+  description: Further eases alignment by widening the GOOD window.
+  category: 0
+  tier: 1
+  cost: 14
+  prerequisite: {fileID: 11400000, guid: 4d590c4023a84e9baf662a5d3950fac5, type: 2}
+  effects:
+  - effectType: 1
+    value: 0.02

--- a/Assets/GW/Resources/Upgrades/Acc_TunedGuides.asset.meta
+++ b/Assets/GW/Resources/Upgrades/Acc_TunedGuides.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ba6cef94aec4852b2dab6626c8701f2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Resources/Upgrades/Acc_WideSeal.asset
+++ b/Assets/GW/Resources/Upgrades/Acc_WideSeal.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5e3d96834e143789b7bcee3a8b11db3, type: 3}
+  m_Name: Acc_WideSeal
+  m_EditorClassIdentifier: 
+  id: acc_wide_seal
+  title: Wide Seal Guides
+  description: Slightly widens the perfect seal window for every line.
+  category: 0
+  tier: 0
+  cost: 8
+  prerequisite: {fileID: 0}
+  effects:
+  - effectType: 0
+    value: 0.01

--- a/Assets/GW/Resources/Upgrades/Acc_WideSeal.asset.meta
+++ b/Assets/GW/Resources/Upgrades/Acc_WideSeal.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4d590c4023a84e9baf662a5d3950fac5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Resources/Upgrades/Bliss_GoodAura.asset
+++ b/Assets/GW/Resources/Upgrades/Bliss_GoodAura.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5e3d96834e143789b7bcee3a8b11db3, type: 3}
+  m_Name: Bliss_GoodAura
+  m_EditorClassIdentifier: 
+  id: bliss_good_aura
+  title: Good Aura
+  description: GOOD seals contribute more to the Bliss bar.
+  category: 2
+  tier: 1
+  cost: 15
+  prerequisite: {fileID: 11400000, guid: 807852d51e544769ad11f62c8cdd7391, type: 2}
+  effects:
+  - effectType: 6
+    value: 0.01

--- a/Assets/GW/Resources/Upgrades/Bliss_GoodAura.asset.meta
+++ b/Assets/GW/Resources/Upgrades/Bliss_GoodAura.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bdb0b1a9d15c4777aabacde4bbb31f59
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Resources/Upgrades/Bliss_GuardedFlow.asset
+++ b/Assets/GW/Resources/Upgrades/Bliss_GuardedFlow.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5e3d96834e143789b7bcee3a8b11db3, type: 3}
+  m_Name: Bliss_GuardedFlow
+  m_EditorClassIdentifier: 
+  id: bliss_guarded_flow
+  title: Guarded Flow
+  description: Losing Bliss hurts less; failures drain less charge.
+  category: 2
+  tier: 2
+  cost: 21
+  prerequisite: {fileID: 11400000, guid: bdb0b1a9d15c4777aabacde4bbb31f59, type: 2}
+  effects:
+  - effectType: 7
+    value: -0.05

--- a/Assets/GW/Resources/Upgrades/Bliss_GuardedFlow.asset.meta
+++ b/Assets/GW/Resources/Upgrades/Bliss_GuardedFlow.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b654b4bf50d04518bb7c9b8d0afdcdc1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Resources/Upgrades/Bliss_PerfectRush.asset
+++ b/Assets/GW/Resources/Upgrades/Bliss_PerfectRush.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5e3d96834e143789b7bcee3a8b11db3, type: 3}
+  m_Name: Bliss_PerfectRush
+  m_EditorClassIdentifier: 
+  id: bliss_perfect_rush
+  title: Perfect Rush
+  description: Each PERFECT grants extra Bliss charge.
+  category: 2
+  tier: 0
+  cost: 9
+  prerequisite: {fileID: 0}
+  effects:
+  - effectType: 5
+    value: 0.02

--- a/Assets/GW/Resources/Upgrades/Bliss_PerfectRush.asset.meta
+++ b/Assets/GW/Resources/Upgrades/Bliss_PerfectRush.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 807852d51e544769ad11f62c8cdd7391
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Resources/Upgrades/Stab_CalmBelts.asset
+++ b/Assets/GW/Resources/Upgrades/Stab_CalmBelts.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5e3d96834e143789b7bcee3a8b11db3, type: 3}
+  m_Name: Stab_CalmBelts
+  m_EditorClassIdentifier: 
+  id: stab_calm_belts
+  title: Calm Belts
+  description: Slows belts by 10% for steadier timing.
+  category: 1
+  tier: 0
+  cost: 10
+  prerequisite: {fileID: 0}
+  effects:
+  - effectType: 8
+    value: 0.9

--- a/Assets/GW/Resources/Upgrades/Stab_CalmBelts.asset.meta
+++ b/Assets/GW/Resources/Upgrades/Stab_CalmBelts.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 57bdb26dbd2a4bab911f187ac3caa4ef
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Resources/Upgrades/Stab_SoftLanding.asset
+++ b/Assets/GW/Resources/Upgrades/Stab_SoftLanding.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5e3d96834e143789b7bcee3a8b11db3, type: 3}
+  m_Name: Stab_SoftLanding
+  m_EditorClassIdentifier: 
+  id: stab_soft_landing
+  title: Soft Landing Pads
+  description: Cushions mistakes by reducing the score loss on fails.
+  category: 1
+  tier: 2
+  cost: 24
+  prerequisite: {fileID: 11400000, guid: 8e8b882219f34243897b39329466f6ac, type: 2}
+  effects:
+  - effectType: 10
+    value: 3

--- a/Assets/GW/Resources/Upgrades/Stab_SoftLanding.asset.meta
+++ b/Assets/GW/Resources/Upgrades/Stab_SoftLanding.asset.meta
@@ -1,8 +1,8 @@
 fileFormatVersion: 2
-guid: 370a79b933834c2cbde3c062dd215386
-folderAsset: yes
-DefaultImporter:
+guid: c6e511c1d8c94f1dacdca51bd29a1882
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 11400000
   userData:
   assetBundleName:
   assetBundleVariant:

--- a/Assets/GW/Resources/Upgrades/Stab_TimedFeed.asset
+++ b/Assets/GW/Resources/Upgrades/Stab_TimedFeed.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f5e3d96834e143789b7bcee3a8b11db3, type: 3}
+  m_Name: Stab_TimedFeed
+  m_EditorClassIdentifier: 
+  id: stab_timed_feed
+  title: Timed Feeders
+  description: Adds a brief pause between candies, granting reaction time.
+  category: 1
+  tier: 1
+  cost: 16
+  prerequisite: {fileID: 11400000, guid: 57bdb26dbd2a4bab911f187ac3caa4ef, type: 2}
+  effects:
+  - effectType: 9
+    value: 1.1

--- a/Assets/GW/Resources/Upgrades/Stab_TimedFeed.asset.meta
+++ b/Assets/GW/Resources/Upgrades/Stab_TimedFeed.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e8b882219f34243897b39329466f6ac
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Scripts/Core/UpgradeEnums.cs
+++ b/Assets/GW/Scripts/Core/UpgradeEnums.cs
@@ -1,0 +1,24 @@
+namespace GW.Core
+{
+    public enum UpgradeCategory
+    {
+        Accuracy,
+        Stability,
+        BlissControl,
+    }
+
+    public enum UpgradeEffectType
+    {
+        IncreasePerfectWindow,
+        IncreaseGoodWindow,
+        AdjustComboStep,
+        IncreaseMaxMultiplierLevel,
+        IncreaseMultiplierStep,
+        IncreaseBlissPerfectGain,
+        IncreaseBlissGoodGain,
+        AdjustBlissFailPenalty,
+        AdjustBeltSpeedMultiplier,
+        AdjustSpawnIntervalMultiplier,
+        SetFailPenalty,
+    }
+}

--- a/Assets/GW/Scripts/Core/UpgradeEnums.cs.meta
+++ b/Assets/GW/Scripts/Core/UpgradeEnums.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b7ed0580b494ab0ac72787ed6284995
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Scripts/Gameplay/ContractSystem.cs
+++ b/Assets/GW/Scripts/Gameplay/ContractSystem.cs
@@ -99,6 +99,23 @@ namespace GW.Gameplay
             contractsPanel = null;
         }
 
+        public bool TrySpendCredits(int amount)
+        {
+            if (amount <= 0)
+            {
+                return true;
+            }
+
+            if (credits < amount)
+            {
+                return false;
+            }
+
+            credits -= amount;
+            CreditsChanged?.Invoke(credits);
+            return true;
+        }
+
         private void HandleSealResolved(ConveyorLineController line, SealGrade grade)
         {
             if (line == null || activeContracts.Count == 0)

--- a/Assets/GW/Scripts/Gameplay/SealJudge.cs
+++ b/Assets/GW/Scripts/Gameplay/SealJudge.cs
@@ -19,16 +19,23 @@ namespace GW.Gameplay
 
         public float PerfectWindow => perfectWindow;
         public float GoodWindow => goodWindow;
+        public int ComboStep => comboStep;
+        public int MaxMultiplierLevel => maxMultiplierLevel;
+        public float MultiplierStep => multiplierStep;
+        public float BlissPerfect => blissPerfect;
+        public float BlissGood => blissGood;
+        public float BlissFailPenalty => blissFailPenalty;
+        public int FailPenalty => failPenalty;
 
-        private readonly float perfectWindow;
-        private readonly float goodWindow;
-        private readonly int comboStep;
-        private readonly int maxMultiplierLevel;
-        private readonly float multiplierStep;
-        private readonly float blissPerfect;
-        private readonly float blissGood;
-        private readonly float blissFailPenalty;
-        private readonly int failPenalty;
+        private float perfectWindow;
+        private float goodWindow;
+        private int comboStep;
+        private int maxMultiplierLevel;
+        private float multiplierStep;
+        private float blissPerfect;
+        private float blissGood;
+        private float blissFailPenalty;
+        private int failPenalty;
 
         public SealJudge(
             float perfectWindow,
@@ -140,6 +147,89 @@ namespace GW.Gameplay
 
             Bliss = Mathf.Clamp01(Bliss + amount);
             OnStateChanged?.Invoke();
+        }
+
+        public void ApplyParameters(Parameters parameters)
+        {
+            var changed = false;
+
+            if (parameters.PerfectWindow.HasValue)
+            {
+                perfectWindow = Mathf.Max(0.0001f, parameters.PerfectWindow.Value);
+                changed = true;
+            }
+
+            if (parameters.GoodWindow.HasValue)
+            {
+                goodWindow = Mathf.Max(perfectWindow, parameters.GoodWindow.Value);
+                changed = true;
+            }
+            else
+            {
+                goodWindow = Mathf.Max(goodWindow, perfectWindow);
+            }
+
+            if (parameters.ComboStep.HasValue)
+            {
+                comboStep = Mathf.Max(1, parameters.ComboStep.Value);
+                changed = true;
+            }
+
+            if (parameters.MaxMultiplierLevel.HasValue)
+            {
+                maxMultiplierLevel = Mathf.Max(0, parameters.MaxMultiplierLevel.Value);
+                MultiplierLevel = Mathf.Min(MultiplierLevel, maxMultiplierLevel);
+                changed = true;
+            }
+
+            if (parameters.MultiplierStep.HasValue)
+            {
+                multiplierStep = Mathf.Max(0f, parameters.MultiplierStep.Value);
+                changed = true;
+            }
+
+            if (parameters.BlissPerfect.HasValue)
+            {
+                blissPerfect = Mathf.Max(0f, parameters.BlissPerfect.Value);
+                changed = true;
+            }
+
+            if (parameters.BlissGood.HasValue)
+            {
+                blissGood = Mathf.Max(0f, parameters.BlissGood.Value);
+                changed = true;
+            }
+
+            if (parameters.BlissFailPenalty.HasValue)
+            {
+                blissFailPenalty = Mathf.Max(0f, parameters.BlissFailPenalty.Value);
+                changed = true;
+            }
+
+            if (parameters.FailPenalty.HasValue)
+            {
+                failPenalty = Mathf.Max(0, parameters.FailPenalty.Value);
+                changed = true;
+            }
+
+            if (changed)
+            {
+                OnStateChanged?.Invoke();
+            }
+        }
+
+        [Serializable]
+        public struct Parameters
+        {
+            public float? PerfectWindow;
+            public float? GoodWindow;
+            public int? ComboStep;
+            public int? MaxMultiplierLevel;
+            public float? MultiplierStep;
+            public float? BlissPerfect;
+            public float? BlissGood;
+            public float? BlissFailPenalty;
+            public int? FailPenalty;
         }
     }
 }

--- a/Assets/GW/Scripts/Gameplay/UpgradeNode.cs
+++ b/Assets/GW/Scripts/Gameplay/UpgradeNode.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using GW.Core;
+
+namespace GW.Gameplay
+{
+    [CreateAssetMenu(menuName = "GW/Upgrades/Upgrade Node", fileName = "UpgradeNode")]
+    public sealed class UpgradeNode : ScriptableObject
+    {
+        [SerializeField]
+        private string id = Guid.NewGuid().ToString();
+
+        [SerializeField]
+        private string title = "Upgrade";
+
+        [SerializeField]
+        [TextArea]
+        private string description = "";
+
+        [SerializeField]
+        private UpgradeCategory category = UpgradeCategory.Accuracy;
+
+        [SerializeField]
+        [Range(0, 5)]
+        private int tier;
+
+        [SerializeField]
+        [Min(0)]
+        private int cost = 5;
+
+        [SerializeField]
+        private UpgradeNode prerequisite;
+
+        [SerializeField]
+        private List<UpgradeEffectDefinition> effects = new();
+
+        public string Id => string.IsNullOrWhiteSpace(id) ? title : id;
+        public string Title => title;
+        public string Description => description;
+        public UpgradeCategory Category => category;
+        public int Tier => Mathf.Max(0, tier);
+        public int Cost => Mathf.Max(0, cost);
+        public UpgradeNode Prerequisite => prerequisite;
+        public IReadOnlyList<UpgradeEffectDefinition> Effects => effects;
+    }
+
+    [Serializable]
+    public sealed class UpgradeEffectDefinition
+    {
+        [SerializeField]
+        private UpgradeEffectType effectType = UpgradeEffectType.IncreasePerfectWindow;
+
+        [SerializeField]
+        private float value = 0.01f;
+
+        public UpgradeEffectType EffectType => effectType;
+        public float Value => value;
+    }
+}

--- a/Assets/GW/Scripts/Gameplay/UpgradeNode.cs.meta
+++ b/Assets/GW/Scripts/Gameplay/UpgradeNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f5e3d96834e143789b7bcee3a8b11db3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Scripts/Gameplay/UpgradeSystem.cs
+++ b/Assets/GW/Scripts/Gameplay/UpgradeSystem.cs
@@ -1,0 +1,307 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using GW.Core;
+using GW.UI;
+
+namespace GW.Gameplay
+{
+    [DisallowMultipleComponent]
+    public sealed class UpgradeSystem : MonoBehaviour
+    {
+        [Header("Bindings")]
+        [SerializeField]
+        private ContractSystem contractSystem;
+
+        [SerializeField]
+        private List<ConveyorLineController> lines = new();
+
+        [SerializeField]
+        private UpgradePanel upgradePanel;
+
+        [Header("Library")]
+        [SerializeField]
+        private List<UpgradeNode> upgradeNodes = new();
+
+        [SerializeField]
+        private bool autoPopulateFromResources = true;
+
+        [SerializeField]
+        private string resourcesPath = "GW/Upgrades";
+
+        private readonly HashSet<string> purchasedNodeIds = new();
+        private readonly Dictionary<string, UpgradeNode> nodeLookup = new();
+
+        public event Action<UpgradeNode> UpgradePurchased;
+        public event Action StateChanged;
+
+        public int AvailableCredits => contractSystem?.Credits ?? 0;
+
+        private void Awake()
+        {
+            nodeLookup.Clear();
+            BuildLookup(upgradeNodes);
+
+            if (autoPopulateFromResources && !string.IsNullOrEmpty(resourcesPath))
+            {
+                var loadedNodes = Resources.LoadAll<UpgradeNode>(resourcesPath);
+                foreach (var node in loadedNodes)
+                {
+                    if (node == null)
+                    {
+                        continue;
+                    }
+
+                    if (!nodeLookup.ContainsKey(node.Id))
+                    {
+                        upgradeNodes.Add(node);
+                    }
+
+                    nodeLookup[node.Id] = node;
+                }
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (contractSystem != null)
+            {
+                contractSystem.CreditsChanged += HandleCreditsChanged;
+            }
+
+            upgradePanel?.BindSystem(this);
+            ApplyAllUpgrades();
+            RaiseStateChanged();
+        }
+
+        private void Start()
+        {
+            // Ensure upgrades are applied after all lines complete their setup.
+            ApplyAllUpgrades();
+            RaiseStateChanged();
+        }
+
+        private void OnDisable()
+        {
+            if (contractSystem != null)
+            {
+                contractSystem.CreditsChanged -= HandleCreditsChanged;
+            }
+
+            upgradePanel?.UnbindSystem(this);
+        }
+
+        public IReadOnlyCollection<string> PurchasedNodeIds => purchasedNodeIds;
+
+        public bool IsPurchased(UpgradeNode node)
+        {
+            if (node == null)
+            {
+                return false;
+            }
+
+            return purchasedNodeIds.Contains(node.Id);
+        }
+
+        public bool IsUnlocked(UpgradeNode node)
+        {
+            if (node == null)
+            {
+                return false;
+            }
+
+            var prerequisite = node.Prerequisite;
+            if (prerequisite == null)
+            {
+                return true;
+            }
+
+            return IsPurchased(prerequisite);
+        }
+
+        public bool CanPurchase(UpgradeNode node)
+        {
+            if (node == null)
+            {
+                return false;
+            }
+
+            if (!nodeLookup.ContainsKey(node.Id))
+            {
+                return false;
+            }
+
+            if (IsPurchased(node))
+            {
+                return false;
+            }
+
+            if (!IsUnlocked(node))
+            {
+                return false;
+            }
+
+            return AvailableCredits >= node.Cost;
+        }
+
+        public bool TryPurchase(UpgradeNode node)
+        {
+            if (!CanPurchase(node))
+            {
+                return false;
+            }
+
+            if (contractSystem != null && !contractSystem.TrySpendCredits(node.Cost))
+            {
+                return false;
+            }
+
+            purchasedNodeIds.Add(node.Id);
+            ApplyAllUpgrades();
+            UpgradePurchased?.Invoke(node);
+            RaiseStateChanged();
+            return true;
+        }
+
+        private void HandleCreditsChanged(int _)
+        {
+            RaiseStateChanged();
+        }
+
+        private void RaiseStateChanged()
+        {
+            StateChanged?.Invoke();
+        }
+
+        private void ApplyAllUpgrades()
+        {
+            var perfectWindowAdd = 0f;
+            var goodWindowAdd = 0f;
+            var comboStepDelta = 0;
+            var maxMultiplierDelta = 0;
+            var multiplierStepAdd = 0f;
+            var blissPerfectAdd = 0f;
+            var blissGoodAdd = 0f;
+            var blissFailPenaltyAdd = 0f;
+            var beltSpeedMultiplier = 1f;
+            var spawnIntervalMultiplier = 1f;
+            int? failPenaltyOverride = null;
+
+            foreach (var id in purchasedNodeIds)
+            {
+                if (!nodeLookup.TryGetValue(id, out var node) || node == null)
+                {
+                    continue;
+                }
+
+                foreach (var effect in node.Effects)
+                {
+                    if (effect == null)
+                    {
+                        continue;
+                    }
+
+                    var value = effect.Value;
+
+                    switch (effect.EffectType)
+                    {
+                        case UpgradeEffectType.IncreasePerfectWindow:
+                            perfectWindowAdd += value;
+                            break;
+                        case UpgradeEffectType.IncreaseGoodWindow:
+                            goodWindowAdd += value;
+                            break;
+                        case UpgradeEffectType.AdjustComboStep:
+                            comboStepDelta += Mathf.RoundToInt(value);
+                            break;
+                        case UpgradeEffectType.IncreaseMaxMultiplierLevel:
+                            maxMultiplierDelta += Mathf.RoundToInt(value);
+                            break;
+                        case UpgradeEffectType.IncreaseMultiplierStep:
+                            multiplierStepAdd += value;
+                            break;
+                        case UpgradeEffectType.IncreaseBlissPerfectGain:
+                            blissPerfectAdd += value;
+                            break;
+                        case UpgradeEffectType.IncreaseBlissGoodGain:
+                            blissGoodAdd += value;
+                            break;
+                        case UpgradeEffectType.AdjustBlissFailPenalty:
+                            blissFailPenaltyAdd += value;
+                            break;
+                        case UpgradeEffectType.AdjustBeltSpeedMultiplier:
+                            beltSpeedMultiplier *= Mathf.Clamp(value, 0.25f, 4f);
+                            break;
+                        case UpgradeEffectType.AdjustSpawnIntervalMultiplier:
+                            spawnIntervalMultiplier *= Mathf.Clamp(value, 0.25f, 4f);
+                            break;
+                        case UpgradeEffectType.SetFailPenalty:
+                            var penaltyValue = Mathf.Max(0, Mathf.RoundToInt(value));
+                            if (failPenaltyOverride.HasValue)
+                            {
+                                failPenaltyOverride = Mathf.Min(failPenaltyOverride.Value, penaltyValue);
+                            }
+                            else
+                            {
+                                failPenaltyOverride = penaltyValue;
+                            }
+                            break;
+                    }
+                }
+            }
+
+            for (var i = 0; i < lines.Count; i++)
+            {
+                var line = lines[i];
+                if (line == null)
+                {
+                    continue;
+                }
+
+                var perfectWindow = Mathf.Clamp(line.BasePerfectWindow + perfectWindowAdd, 0.01f, 0.5f);
+                var goodWindow = Mathf.Clamp(line.BaseGoodWindow + goodWindowAdd, perfectWindow, 0.6f);
+                var comboValue = Mathf.Max(1, line.BaseComboStep + comboStepDelta);
+                var maxMultiplier = Mathf.Max(0, line.BaseMaxMultiplierLevel + maxMultiplierDelta);
+                var multiplierStep = Mathf.Max(0f, line.BaseMultiplierStep + multiplierStepAdd);
+                var blissPerfectValue = Mathf.Max(0f, line.BaseBlissPerfect + blissPerfectAdd);
+                var blissGoodValue = Mathf.Max(0f, line.BaseBlissGood + blissGoodAdd);
+                var blissFailPenaltyValue = Mathf.Max(0f, line.BaseBlissFailPenalty + blissFailPenaltyAdd);
+                var failPenalty = failPenaltyOverride.HasValue
+                    ? Mathf.Max(0, failPenaltyOverride.Value)
+                    : line.BaseFailPenalty;
+
+                line.ApplyJudgeOverrides(
+                    perfectWindow,
+                    goodWindow,
+                    comboValue,
+                    maxMultiplier,
+                    multiplierStep,
+                    blissPerfectValue,
+                    blissGoodValue,
+                    blissFailPenaltyValue,
+                    failPenalty);
+
+                line.SetSpeedMultiplier(Mathf.Clamp(beltSpeedMultiplier, 0.25f, 4f));
+                line.SetSpawnIntervalMultiplier(Mathf.Clamp(spawnIntervalMultiplier, 0.25f, 4f));
+            }
+        }
+
+        private void BuildLookup(IEnumerable<UpgradeNode> source)
+        {
+            if (source == null)
+            {
+                return;
+            }
+
+            foreach (var node in source)
+            {
+                if (node == null)
+                {
+                    continue;
+                }
+
+                nodeLookup[node.Id] = node;
+            }
+        }
+    }
+}

--- a/Assets/GW/Scripts/Gameplay/UpgradeSystem.cs.meta
+++ b/Assets/GW/Scripts/Gameplay/UpgradeSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9dab0b178d4843c6841c0552c229d6ca
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Scripts/UI/HUDRoot.cs
+++ b/Assets/GW/Scripts/UI/HUDRoot.cs
@@ -110,7 +110,8 @@ namespace GW.UI
                 return;
             }
 
-            var multiplierValue = 1f + level * 0.5f;
+            var step = boundLine?.Judge?.MultiplierStep ?? 0.5f;
+            var multiplierValue = 1f + level * step;
             multiplierText.text = string.Format(multiplierFormat, multiplierValue);
         }
 

--- a/Assets/GW/Scripts/UI/UpgradeNodeView.cs
+++ b/Assets/GW/Scripts/UI/UpgradeNodeView.cs
@@ -1,0 +1,128 @@
+using UnityEngine;
+using UnityEngine.UI;
+using GW.Gameplay;
+
+namespace GW.UI
+{
+    [DisallowMultipleComponent]
+    public sealed class UpgradeNodeView : MonoBehaviour
+    {
+        [SerializeField]
+        private UpgradeNode node;
+
+        [SerializeField]
+        private Text titleText;
+
+        [SerializeField]
+        private Text descriptionText;
+
+        [SerializeField]
+        private Text costText;
+
+        [SerializeField]
+        private Button purchaseButton;
+
+        [SerializeField]
+        private GameObject purchasedIndicator;
+
+        [SerializeField]
+        private GameObject lockedIndicator;
+
+        [SerializeField]
+        private string ownedLabel = "OWNED";
+
+        [SerializeField]
+        private string lockedLabel = "LOCKED";
+
+        private UpgradeSystem system;
+
+        private void Awake()
+        {
+            if (purchaseButton != null)
+            {
+                purchaseButton.onClick.AddListener(HandlePurchaseClicked);
+            }
+
+            Refresh();
+        }
+
+        private void OnDestroy()
+        {
+            if (purchaseButton != null)
+            {
+                purchaseButton.onClick.RemoveListener(HandlePurchaseClicked);
+            }
+        }
+
+        public void Bind(UpgradeSystem upgradeSystem)
+        {
+            system = upgradeSystem;
+            Refresh();
+        }
+
+        public void Refresh()
+        {
+            if (titleText != null)
+            {
+                titleText.text = node != null ? node.Title : string.Empty;
+            }
+
+            if (descriptionText != null)
+            {
+                descriptionText.text = node != null ? node.Description : string.Empty;
+            }
+
+            var isPurchased = system != null && node != null && system.IsPurchased(node);
+            var isUnlocked = system != null && node != null && system.IsUnlocked(node);
+            var canPurchase = system != null && node != null && system.CanPurchase(node);
+
+            if (costText != null)
+            {
+                if (node == null)
+                {
+                    costText.text = string.Empty;
+                }
+                else if (isPurchased)
+                {
+                    costText.text = ownedLabel;
+                }
+                else if (!isUnlocked)
+                {
+                    costText.text = lockedLabel;
+                }
+                else
+                {
+                    costText.text = node.Cost.ToString();
+                }
+            }
+
+            if (purchaseButton != null)
+            {
+                purchaseButton.interactable = canPurchase;
+            }
+
+            if (purchasedIndicator != null)
+            {
+                purchasedIndicator.SetActive(isPurchased);
+            }
+
+            if (lockedIndicator != null)
+            {
+                lockedIndicator.SetActive(node != null && !isPurchased && !isUnlocked);
+            }
+        }
+
+        private void HandlePurchaseClicked()
+        {
+            if (system == null || node == null)
+            {
+                return;
+            }
+
+            if (system.TryPurchase(node))
+            {
+                Refresh();
+            }
+        }
+    }
+}

--- a/Assets/GW/Scripts/UI/UpgradeNodeView.cs.meta
+++ b/Assets/GW/Scripts/UI/UpgradeNodeView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 508c28b3c490485fa2e8016ab3bb3bc7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Scripts/UI/UpgradePanel.cs
+++ b/Assets/GW/Scripts/UI/UpgradePanel.cs
@@ -1,0 +1,125 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using GW.Gameplay;
+
+namespace GW.UI
+{
+    [DisallowMultipleComponent]
+    public sealed class UpgradePanel : MonoBehaviour
+    {
+        [SerializeField]
+        private Text creditsText;
+
+        [SerializeField]
+        private string creditsFormat = "Credits: {0:N0}";
+
+        [SerializeField]
+        private List<UpgradeNodeView> nodeViews = new();
+
+        private UpgradeSystem system;
+        private bool subscribed;
+
+        private void OnEnable()
+        {
+            Subscribe();
+            Refresh();
+        }
+
+        private void OnDisable()
+        {
+            Unsubscribe();
+        }
+
+        public void BindSystem(UpgradeSystem upgradeSystem)
+        {
+            if (system == upgradeSystem)
+            {
+                RefreshViews();
+                RefreshCredits();
+                return;
+            }
+
+            Unsubscribe();
+            system = upgradeSystem;
+
+            foreach (var view in nodeViews)
+            {
+                view?.Bind(system);
+            }
+
+            Subscribe();
+            Refresh();
+        }
+
+        public void UnbindSystem(UpgradeSystem upgradeSystem)
+        {
+            if (system != upgradeSystem)
+            {
+                return;
+            }
+
+            Unsubscribe();
+            system = null;
+
+            foreach (var view in nodeViews)
+            {
+                view?.Bind(null);
+            }
+
+            Refresh();
+        }
+
+        private void Subscribe()
+        {
+            if (system == null || subscribed)
+            {
+                return;
+            }
+
+            system.StateChanged += HandleStateChanged;
+            subscribed = true;
+        }
+
+        private void Unsubscribe()
+        {
+            if (system == null || !subscribed)
+            {
+                return;
+            }
+
+            system.StateChanged -= HandleStateChanged;
+            subscribed = false;
+        }
+
+        private void HandleStateChanged()
+        {
+            Refresh();
+        }
+
+        private void Refresh()
+        {
+            RefreshCredits();
+            RefreshViews();
+        }
+
+        private void RefreshCredits()
+        {
+            if (creditsText == null)
+            {
+                return;
+            }
+
+            var credits = system?.AvailableCredits ?? 0;
+            creditsText.text = string.Format(creditsFormat, credits);
+        }
+
+        private void RefreshViews()
+        {
+            foreach (var view in nodeViews)
+            {
+                view?.Refresh();
+            }
+        }
+    }
+}

--- a/Assets/GW/Scripts/UI/UpgradePanel.cs.meta
+++ b/Assets/GW/Scripts/UI/UpgradePanel.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 80c33c2b71dc43c386eafee56c668e33
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add an upgrade system that aggregates purchased nodes and applies their effects to every conveyor line
- expand gameplay and UI scripts to support dynamic judge tuning, credit spending, and multiplier display updates
- populate a 3×3 upgrade library with ScriptableObject assets and hook an upgrade panel for purchasing

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d872aa7e808322a1821263a9ff96b8