### PR TITLE
Add UI namespace import for ContractSystem

### DIFF
--- a/Assets/GW/Scripts/Gameplay/ContractSystem.cs
+++ b/Assets/GW/Scripts/Gameplay/ContractSystem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using UnityEngine;
 using GW.Core;
+using GW.UI;
 
 namespace GW.Gameplay
 {


### PR DESCRIPTION
## Summary
- add the GW.UI namespace to ContractSystem so ContractsPanel resolves correctly

## Testing
- dotnet build *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d8762ed5588322aa26c55838d75fa6