### PR TITLE
Add basic main menu UI

### DIFF
--- a/Assets/GW/Scenes/MainMenu.unity
+++ b/Assets/GW/Scenes/MainMenu.unity
@@ -217,6 +217,9 @@ GameObject:
   m_Component:
   - component: {fileID: 7363528587119039423}
   - component: {fileID: 7363528587119039422}
+  - component: {fileID: 7363528587119039425}
+  - component: {fileID: 7363528587119039426}
+  - component: {fileID: 7363528587119039424}
   - component: {fileID: 7363528587119039421}
   m_Layer: 5
   m_Name: MainMenuRoot
@@ -266,6 +269,63 @@ Canvas:
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
+--- !u!114 &7363528587119039425
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7363528587119039420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0.5
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &7363528587119039426
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7363528587119039420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &7363528587119039424
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7363528587119039420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0eb4a922a3084219b77ef03027423bc0, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  titleText: GOLDEN WRAP
+  subtitleText: "Бесконечная фабрика золотой обёртки"
+  playButtonText: "Играть"
+  showcaseTitleText: "Витрина узоров"
+  showcaseSubtitleText: "Здесь появятся ваши любимые паттерны фольги."
 --- !u!114 &7363528587119039421
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -278,3 +338,70 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c2e17b560d8411a90d7e4eb89c42cf2, type: 3}
   m_Name:
   m_EditorClassIdentifier:
+--- !u!1 &7261533302796269233
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7261533302796269232}
+  - component: {fileID: 7261533302796269231}
+  - component: {fileID: 7261533302796269230}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7261533302796269232
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7261533302796269233}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7261533302796269231
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7261533302796269233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!114 &7261533302796269230
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7261533302796269233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0

--- a/Assets/GW/Scripts/Core/FoilPatternRarity.cs
+++ b/Assets/GW/Scripts/Core/FoilPatternRarity.cs
@@ -1,0 +1,10 @@
+namespace GW.Core
+{
+    public enum FoilPatternRarity
+    {
+        Common = 0,
+        Rare = 1,
+        Epic = 2,
+        Legendary = 3,
+    }
+}

--- a/Assets/GW/Scripts/Gameplay/CandyActor.cs
+++ b/Assets/GW/Scripts/Gameplay/CandyActor.cs
@@ -10,15 +10,44 @@ namespace GW.Gameplay
 
         public bool IsActive => isActiveAndEnabled;
 
+        [Header("Rendering")]
+        [SerializeField]
+        private SpriteRenderer foilRenderer;
+
+        [SerializeField]
+        private SpriteRenderer highlightRenderer;
+
+        [SerializeField]
+        [Tooltip("How quickly the foil visuals interpolate toward the target tint each frame.")]
+        private float foilLerpSpeed = 8f;
+
+        [SerializeField]
+        private Color defaultFoilColor = new Color(0.78f, 0.66f, 0.28f, 1f);
+
+        [SerializeField]
+        private Color defaultHighlightColor = new Color(0.95f, 0.83f, 0.42f, 1f);
+
         private ConveyorLineController owner;
         private Vector3 direction;
         private float speed;
+        private FoilPatternRuntime? activePattern;
+        private float patternPulseTime;
+        private Vector3 highlightDefaultEuler;
+        private bool highlightEulerCached;
 
-        public void Activate(ConveyorLineController line, Vector3 spawnPosition, Vector3 direction, float speed)
+        public void Activate(
+            ConveyorLineController line,
+            Vector3 spawnPosition,
+            Vector3 direction,
+            float speed,
+            FoilPatternRuntime? pattern = null)
         {
             owner = line;
             this.direction = direction;
             this.speed = speed;
+
+            EnsureRenderers();
+            ApplyFoilPattern(pattern, true);
 
             transform.position = spawnPosition;
             gameObject.SetActive(true);
@@ -27,6 +56,7 @@ namespace GW.Gameplay
         public void Tick(float deltaTime)
         {
             transform.position += direction * speed * deltaTime;
+            UpdateFoilVisual(deltaTime);
         }
 
         public void SetSpeed(float value)
@@ -38,7 +68,119 @@ namespace GW.Gameplay
         {
             gameObject.SetActive(false);
             owner = null;
+            ClearPatternImmediate();
             Despawned?.Invoke(this);
+        }
+
+        public void ApplyFoilPattern(FoilPatternRuntime? pattern, bool instant = false)
+        {
+            EnsureRenderers();
+
+            activePattern = pattern;
+            patternPulseTime = 0f;
+
+            if (instant)
+            {
+                UpdateFoilVisual(instant ? 1f : Time.deltaTime, instant);
+            }
+        }
+
+        private void UpdateFoilVisual(float deltaTime, bool forceInstant = false)
+        {
+            if (foilRenderer == null && highlightRenderer == null)
+            {
+                return;
+            }
+
+            var lerpFactor = forceInstant ? 1f : Mathf.Clamp01(deltaTime * foilLerpSpeed);
+
+            Color targetFoil = defaultFoilColor;
+            Color targetHighlight = defaultHighlightColor;
+
+            if (activePattern.HasValue)
+            {
+                var pattern = activePattern.Value;
+                patternPulseTime += deltaTime * Mathf.Max(0.1f, pattern.PulseSpeed);
+                var wave = 0.5f + 0.5f * Mathf.Sin(patternPulseTime * Mathf.PI * 2f);
+
+                targetFoil = Color.Lerp(pattern.PrimaryTint, pattern.SecondaryTint, wave);
+                targetFoil = Color.Lerp(defaultFoilColor, targetFoil, Mathf.Clamp01(pattern.Specular + pattern.EmbossDepth * 0.5f));
+
+                targetHighlight = Color.Lerp(pattern.SecondaryTint, Color.white, 0.15f + 0.4f * wave);
+
+                if (highlightRenderer != null)
+                {
+                    CacheHighlightEuler();
+                    var rotation = highlightDefaultEuler;
+                    var angle = Mathf.Atan2(pattern.FlowDirection.y, pattern.FlowDirection.x) * Mathf.Rad2Deg;
+                    rotation.z = angle;
+                    highlightRenderer.transform.localEulerAngles = rotation;
+                }
+            }
+            else if (highlightRenderer != null)
+            {
+                CacheHighlightEuler();
+                highlightRenderer.transform.localEulerAngles = highlightDefaultEuler;
+            }
+
+            if (foilRenderer != null)
+            {
+                foilRenderer.color = Color.Lerp(foilRenderer.color, targetFoil, lerpFactor);
+            }
+
+            if (highlightRenderer != null)
+            {
+                highlightRenderer.color = Color.Lerp(highlightRenderer.color, targetHighlight, lerpFactor);
+            }
+        }
+
+        private void EnsureRenderers()
+        {
+            if (foilRenderer == null)
+            {
+                foilRenderer = GetComponentInChildren<SpriteRenderer>();
+                if (foilRenderer != null)
+                {
+                    defaultFoilColor = foilRenderer.color;
+                }
+            }
+
+            if (highlightRenderer != null && !highlightEulerCached)
+            {
+                highlightDefaultEuler = highlightRenderer.transform.localEulerAngles;
+                highlightEulerCached = true;
+                defaultHighlightColor = highlightRenderer.color;
+            }
+        }
+
+        private void CacheHighlightEuler()
+        {
+            if (highlightRenderer == null || highlightEulerCached)
+            {
+                return;
+            }
+
+            highlightDefaultEuler = highlightRenderer.transform.localEulerAngles;
+            highlightEulerCached = true;
+            defaultHighlightColor = highlightRenderer.color;
+        }
+
+        private void ClearPatternImmediate()
+        {
+            activePattern = null;
+            patternPulseTime = 0f;
+
+            if (foilRenderer != null)
+            {
+                foilRenderer.color = defaultFoilColor;
+            }
+
+            if (highlightRenderer != null)
+            {
+                CacheHighlightEuler();
+                highlightRenderer.transform.localEulerAngles = highlightDefaultEuler;
+                highlightRenderer.color = defaultHighlightColor;
+            }
         }
     }
 }

--- a/Assets/GW/Scripts/Gameplay/FoilPatternDef.cs
+++ b/Assets/GW/Scripts/Gameplay/FoilPatternDef.cs
@@ -1,0 +1,73 @@
+using System;
+using UnityEngine;
+using GW.Core;
+
+namespace GW.Gameplay
+{
+    [CreateAssetMenu(menuName = "GW/Foil Patterns/Foil Pattern Definition", fileName = "FoilPatternDef")]
+    public sealed class FoilPatternDef : ScriptableObject
+    {
+        [SerializeField]
+        private string id = Guid.NewGuid().ToString();
+
+        [SerializeField]
+        private string displayName = "Foil Pattern";
+
+        [SerializeField]
+        [Tooltip("Optional icon that can be shown in the showcase UI.")]
+        private Sprite icon;
+
+        [SerializeField]
+        [Range(0f, 1f)]
+        [Tooltip("How intense the specular highlight should be when this pattern is active.")]
+        private float specular = 0.6f;
+
+        [SerializeField]
+        [Min(0.01f)]
+        [Tooltip("Relative frequency of the foil ridges. Higher values mean tighter lines.")]
+        private float lineFrequency = 6f;
+
+        [SerializeField]
+        [Range(-180f, 180f)]
+        [Tooltip("Base angle of the foil emboss lines in degrees.")]
+        private float lineAngle = 45f;
+
+        [SerializeField]
+        [Range(0f, 1f)]
+        [Tooltip("Perceived emboss depth for the foil.")]
+        private float embossDepth = 0.25f;
+
+        [SerializeField]
+        [Tooltip("Seed used for deterministic procedural details.")]
+        private int seed;
+
+        [SerializeField]
+        private FoilPatternRarity rarity = FoilPatternRarity.Common;
+
+        [SerializeField]
+        [Tooltip("Optional short flavour text shown in the showcase.")]
+        [TextArea]
+        private string description;
+
+        public string Id => id;
+        public string DisplayName => string.IsNullOrWhiteSpace(displayName) ? name : displayName;
+        public Sprite Icon => icon;
+        public float Specular => Mathf.Clamp01(specular);
+        public float LineFrequency => Mathf.Max(0.01f, lineFrequency);
+        public float LineAngle => lineAngle;
+        public float EmbossDepth => Mathf.Clamp01(embossDepth);
+        public int Seed => seed;
+        public FoilPatternRarity Rarity => rarity;
+        public string Description => description;
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                displayName = name;
+            }
+        }
+#endif
+    }
+}

--- a/Assets/GW/Scripts/Gameplay/FoilPatternLibrary.cs
+++ b/Assets/GW/Scripts/Gameplay/FoilPatternLibrary.cs
@@ -1,0 +1,361 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using GW.Core;
+
+namespace GW.Gameplay
+{
+    /// <summary>
+    /// Holds the catalogue of foil patterns and provides helper methods for rarity-based selection.
+    /// </summary>
+    [CreateAssetMenu(menuName = "GW/Foil Patterns/Foil Pattern Library", fileName = "FoilPatternLibrary")]
+    public sealed class FoilPatternLibrary : ScriptableObject
+    {
+        [Serializable]
+        private struct RarityWeight
+        {
+            public FoilPatternRarity Rarity;
+            [Min(0)]
+            public int Weight;
+        }
+
+        [SerializeField]
+        [Tooltip("All foil patterns that can be used in the game.")]
+        private List<FoilPatternDef> patterns = new List<FoilPatternDef>();
+
+        [SerializeField]
+        [Tooltip("Optional weight overrides that control the probability of each rarity when sampling.")]
+        private List<RarityWeight> rarityWeights = new List<RarityWeight>()
+        {
+            new RarityWeight { Rarity = FoilPatternRarity.Common, Weight = 70 },
+            new RarityWeight { Rarity = FoilPatternRarity.Rare, Weight = 20 },
+            new RarityWeight { Rarity = FoilPatternRarity.Epic, Weight = 9 },
+            new RarityWeight { Rarity = FoilPatternRarity.Legendary, Weight = 1 },
+        };
+
+        [SerializeField]
+        [Tooltip("Base tint applied for each rarity when generating runtime data.")]
+        private Gradient commonTintGradient;
+
+        [SerializeField]
+        private Gradient rareTintGradient;
+
+        [SerializeField]
+        private Gradient epicTintGradient;
+
+        [SerializeField]
+        private Gradient legendaryTintGradient;
+
+        private readonly Dictionary<string, FoilPatternDef> patternLookup = new Dictionary<string, FoilPatternDef>();
+        private static readonly List<FoilPatternDef> PatternBuffer = new List<FoilPatternDef>();
+        private static readonly List<int> WeightBuffer = new List<int>();
+
+        public IReadOnlyList<FoilPatternDef> Patterns => patterns;
+
+        private void OnEnable()
+        {
+            RebuildLookup();
+            EnsureGradients();
+        }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            RebuildLookup();
+            EnsureGradients();
+        }
+#endif
+
+        public FoilPatternDef GetById(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+            {
+                return null;
+            }
+
+            return patternLookup.TryGetValue(id, out var def) ? def : null;
+        }
+
+        public bool TryGetById(string id, out FoilPatternDef def)
+        {
+            def = GetById(id);
+            return def != null;
+        }
+
+        public FoilPatternDef GetRandomPattern(FoilPatternRarity? rarityOverride = null, System.Random random = null)
+        {
+            if (patterns == null || patterns.Count == 0)
+            {
+                return null;
+            }
+
+            if (rarityOverride.HasValue)
+            {
+                PatternBuffer.Clear();
+                var rarity = rarityOverride.Value;
+
+                for (var i = 0; i < patterns.Count; i++)
+                {
+                    var pattern = patterns[i];
+                    if (pattern == null || pattern.Rarity != rarity)
+                    {
+                        continue;
+                    }
+
+                    PatternBuffer.Add(pattern);
+                }
+
+                if (PatternBuffer.Count == 0)
+                {
+                    return null;
+                }
+
+                var index = SampleIndex(PatternBuffer.Count, random);
+                return PatternBuffer[index];
+            }
+
+            PatternBuffer.Clear();
+            WeightBuffer.Clear();
+
+            var totalWeight = 0;
+            for (var i = 0; i < patterns.Count; i++)
+            {
+                var pattern = patterns[i];
+                if (pattern == null)
+                {
+                    continue;
+                }
+
+                var weight = Mathf.Max(0, GetWeight(pattern.Rarity));
+                if (weight <= 0)
+                {
+                    continue;
+                }
+
+                PatternBuffer.Add(pattern);
+                WeightBuffer.Add(weight);
+                totalWeight += weight;
+            }
+
+            if (totalWeight <= 0)
+            {
+                return null;
+            }
+
+            var roll = SampleWeighted(totalWeight, random);
+            for (var i = 0; i < PatternBuffer.Count; i++)
+            {
+                var weight = WeightBuffer[i];
+                if (roll < weight)
+                {
+                    return PatternBuffer[i];
+                }
+
+                roll -= weight;
+            }
+
+            return PatternBuffer.Count > 0 ? PatternBuffer[PatternBuffer.Count - 1] : null;
+        }
+
+        public FoilPatternRuntime? GetRandomRuntime(FoilPatternRarity? rarityOverride = null, System.Random random = null)
+        {
+            var pattern = GetRandomPattern(rarityOverride, random);
+            if (pattern == null)
+            {
+                return null;
+            }
+
+            return CreateRuntime(pattern, random);
+        }
+
+        public FoilPatternRuntime CreateRuntime(FoilPatternDef pattern, System.Random random = null)
+        {
+            if (pattern == null)
+            {
+                throw new ArgumentNullException(nameof(pattern));
+            }
+
+            var rng = random ?? new System.Random(pattern.Seed ^ (int)DateTime.UtcNow.Ticks);
+            var jitter = (float)(rng.NextDouble() * 30d - 15d);
+            var angle = Mathf.Deg2Rad * (pattern.LineAngle + jitter);
+            var flow = new Vector2(Mathf.Cos(angle), Mathf.Sin(angle));
+            var frequency = pattern.LineFrequency * Mathf.Lerp(0.85f, 1.25f, (float)rng.NextDouble());
+            var primary = EvaluateTint(pattern.Rarity, rng, true);
+            var secondary = EvaluateTint(pattern.Rarity, rng, false);
+            var pulse = Mathf.Lerp(0.5f, 1.75f, (float)rng.NextDouble());
+            return new FoilPatternRuntime(pattern, flow, frequency, pattern.Specular, pattern.EmbossDepth, primary, secondary, pulse);
+        }
+
+        public List<FoilPatternDef> GetPatternsByRarity(FoilPatternRarity rarity, List<FoilPatternDef> buffer = null)
+        {
+            var results = buffer ?? new List<FoilPatternDef>();
+            results.Clear();
+
+            if (patterns == null)
+            {
+                return results;
+            }
+
+            for (var i = 0; i < patterns.Count; i++)
+            {
+                var pattern = patterns[i];
+                if (pattern == null || pattern.Rarity != rarity)
+                {
+                    continue;
+                }
+
+                results.Add(pattern);
+            }
+
+            return results;
+        }
+
+        private int GetWeight(FoilPatternRarity rarity)
+        {
+            if (rarityWeights != null)
+            {
+                for (var i = 0; i < rarityWeights.Count; i++)
+                {
+                    var entry = rarityWeights[i];
+                    if (entry.Rarity == rarity)
+                    {
+                        return entry.Weight;
+                    }
+                }
+            }
+
+            return rarity switch
+            {
+                FoilPatternRarity.Common => 70,
+                FoilPatternRarity.Rare => 20,
+                FoilPatternRarity.Epic => 9,
+                FoilPatternRarity.Legendary => 1,
+                _ => 1,
+            };
+        }
+
+        private static int SampleIndex(int count, System.Random random)
+        {
+            if (count <= 0)
+            {
+                return -1;
+            }
+
+            return random != null ? random.Next(count) : UnityEngine.Random.Range(0, count);
+        }
+
+        private static int SampleWeighted(int totalWeight, System.Random random)
+        {
+            if (totalWeight <= 0)
+            {
+                return 0;
+            }
+
+            return random != null ? random.Next(totalWeight) : Mathf.FloorToInt(UnityEngine.Random.value * totalWeight);
+        }
+
+        private Color EvaluateTint(FoilPatternRarity rarity, System.Random random, bool primary)
+        {
+            var gradient = rarity switch
+            {
+                FoilPatternRarity.Common => commonTintGradient,
+                FoilPatternRarity.Rare => rareTintGradient,
+                FoilPatternRarity.Epic => epicTintGradient,
+                FoilPatternRarity.Legendary => legendaryTintGradient,
+                _ => commonTintGradient,
+            };
+
+            if (gradient == null)
+            {
+                EnsureGradients();
+                gradient = rarity switch
+                {
+                    FoilPatternRarity.Common => commonTintGradient,
+                    FoilPatternRarity.Rare => rareTintGradient,
+                    FoilPatternRarity.Epic => epicTintGradient,
+                    FoilPatternRarity.Legendary => legendaryTintGradient,
+                    _ => commonTintGradient,
+                };
+            }
+
+            var t = primary ? (float)random.NextDouble() * 0.6f : 0.4f + (float)random.NextDouble() * 0.6f;
+            return gradient.Evaluate(Mathf.Clamp01(t));
+        }
+
+        private void RebuildLookup()
+        {
+            patternLookup.Clear();
+
+            if (patterns == null)
+            {
+                return;
+            }
+
+            for (var i = patterns.Count - 1; i >= 0; i--)
+            {
+                var pattern = patterns[i];
+                if (pattern == null)
+                {
+                    patterns.RemoveAt(i);
+                    continue;
+                }
+
+                var key = pattern.Id;
+                if (string.IsNullOrEmpty(key))
+                {
+                    Debug.LogWarning($"Foil pattern '{pattern.name}' has no ID assigned and will be skipped.", pattern);
+                    continue;
+                }
+
+                if (patternLookup.ContainsKey(key))
+                {
+                    Debug.LogWarning($"Duplicate foil pattern id '{key}' detected. Only the first instance will be used.", pattern);
+                    continue;
+                }
+
+                patternLookup[key] = pattern;
+            }
+        }
+
+        private void EnsureGradients()
+        {
+            if (commonTintGradient == null)
+            {
+                commonTintGradient = CreateDefaultGradient(new Color32(201, 166, 70, 255), new Color32(143, 122, 47, 255));
+            }
+
+            if (rareTintGradient == null)
+            {
+                rareTintGradient = CreateDefaultGradient(new Color32(255, 211, 110, 255), new Color32(201, 166, 70, 255));
+            }
+
+            if (epicTintGradient == null)
+            {
+                epicTintGradient = CreateDefaultGradient(new Color32(255, 238, 163, 255), new Color32(201, 166, 70, 255));
+            }
+
+            if (legendaryTintGradient == null)
+            {
+                legendaryTintGradient = CreateDefaultGradient(new Color32(255, 249, 220, 255), new Color32(255, 211, 110, 255));
+            }
+        }
+
+        private static Gradient CreateDefaultGradient(Color a, Color b)
+        {
+            var gradient = new Gradient();
+            gradient.SetKeys(
+                new[]
+                {
+                    new GradientColorKey(a, 0f),
+                    new GradientColorKey(Color.Lerp(a, b, 0.5f), 0.5f),
+                    new GradientColorKey(b, 1f),
+                },
+                new[]
+                {
+                    new GradientAlphaKey(1f, 0f),
+                    new GradientAlphaKey(1f, 1f),
+                });
+            return gradient;
+        }
+    }
+}

--- a/Assets/GW/Scripts/Gameplay/FoilPatternRuntime.cs
+++ b/Assets/GW/Scripts/Gameplay/FoilPatternRuntime.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+namespace GW.Gameplay
+{
+    /// <summary>
+    /// Runtime data for a foil pattern instance. Allows the renderer to display procedural
+    /// variation without mutating the underlying definition asset.
+    /// </summary>
+    public readonly struct FoilPatternRuntime
+    {
+        public FoilPatternRuntime(
+            FoilPatternDef definition,
+            Vector2 flowDirection,
+            float frequency,
+            float specular,
+            float embossDepth,
+            Color primaryTint,
+            Color secondaryTint,
+            float pulseSpeed)
+        {
+            Definition = definition;
+            FlowDirection = flowDirection.sqrMagnitude > Mathf.Epsilon ? flowDirection.normalized : Vector2.right;
+            Frequency = Mathf.Max(0.01f, frequency);
+            Specular = Mathf.Clamp01(specular);
+            EmbossDepth = Mathf.Clamp01(embossDepth);
+            PrimaryTint = primaryTint;
+            SecondaryTint = secondaryTint;
+            PulseSpeed = Mathf.Max(0.01f, pulseSpeed);
+        }
+
+        public FoilPatternDef Definition { get; }
+        public Vector2 FlowDirection { get; }
+        public float Frequency { get; }
+        public float Specular { get; }
+        public float EmbossDepth { get; }
+        public Color PrimaryTint { get; }
+        public Color SecondaryTint { get; }
+        public float PulseSpeed { get; }
+    }
+}

--- a/Assets/GW/Scripts/UI/FoilPatternShowcase.cs
+++ b/Assets/GW/Scripts/UI/FoilPatternShowcase.cs
@@ -1,0 +1,263 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using GW.Gameplay;
+using GW.Core;
+
+namespace GW.UI
+{
+    [DisallowMultipleComponent]
+    public sealed class FoilPatternShowcase : MonoBehaviour
+    {
+        [SerializeField]
+        private FoilPatternLibrary library;
+
+        [SerializeField]
+        private FoilPatternShowcaseItem itemPrefab;
+
+        [SerializeField]
+        private Transform contentRoot;
+
+        [SerializeField]
+        [Tooltip("Maximum number of patterns to show. Zero means show all available.")]
+        private int maxItems = 4;
+
+        [SerializeField]
+        [Tooltip("Automatically refresh the showcase when the object becomes enabled.")]
+        private bool refreshOnEnable = true;
+
+        [SerializeField]
+        [Tooltip("If enabled, at least one entry per rarity is attempted before filling remaining slots.")]
+        private bool ensureRarityCoverage = true;
+
+        [SerializeField]
+        [Tooltip("Allow the same pattern to appear more than once when sampling.")]
+        private bool allowDuplicates;
+
+        [SerializeField]
+        [Tooltip("Create a new runtime variant for each display entry.")]
+        private bool generateRuntimeVariants = true;
+
+        [SerializeField]
+        [Tooltip("Optional fixed seed used to stabilise showcase ordering across sessions.")]
+        private int seed;
+
+        private readonly List<FoilPatternShowcaseItem> spawnedItems = new List<FoilPatternShowcaseItem>();
+        private readonly List<FoilPatternDef> patternPool = new List<FoilPatternDef>();
+        private readonly List<FoilPatternDef> selectionBuffer = new List<FoilPatternDef>();
+        private readonly List<FoilPatternDef> rarityBuffer = new List<FoilPatternDef>();
+        private System.Random random;
+
+        private void Awake()
+        {
+            EnsureContentRoot();
+        }
+
+        private void OnEnable()
+        {
+            if (refreshOnEnable)
+            {
+                Refresh();
+            }
+        }
+
+        public void SetLibrary(FoilPatternLibrary newLibrary)
+        {
+            if (library == newLibrary)
+            {
+                if (refreshOnEnable)
+                {
+                    Refresh();
+                }
+
+                return;
+            }
+
+            library = newLibrary;
+            Refresh();
+        }
+
+        public void Refresh()
+        {
+            EnsureRandom();
+            EnsureContentRoot();
+
+            selectionBuffer.Clear();
+            if (library == null)
+            {
+                ApplySelection(selectionBuffer);
+                return;
+            }
+
+            BuildPatternPool();
+            if (patternPool.Count == 0)
+            {
+                ApplySelection(selectionBuffer);
+                return;
+            }
+
+            if (ensureRarityCoverage)
+            {
+                foreach (FoilPatternRarity rarity in Enum.GetValues(typeof(FoilPatternRarity)))
+                {
+                    rarityBuffer.Clear();
+                    library.GetPatternsByRarity(rarity, rarityBuffer);
+                    if (rarityBuffer.Count == 0)
+                    {
+                        continue;
+                    }
+
+                    var index = random.Next(rarityBuffer.Count);
+                    var def = rarityBuffer[index];
+                    selectionBuffer.Add(def);
+
+                    if (!allowDuplicates)
+                    {
+                        patternPool.Remove(def);
+                    }
+
+                    if (maxItems > 0 && selectionBuffer.Count >= maxItems)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            var targetCount = maxItems <= 0 ? int.MaxValue : Math.Max(0, maxItems);
+            while (selectionBuffer.Count < targetCount && patternPool.Count > 0)
+            {
+                var index = random.Next(patternPool.Count);
+                var def = patternPool[index];
+                selectionBuffer.Add(def);
+
+                if (!allowDuplicates)
+                {
+                    patternPool.RemoveAt(index);
+                }
+            }
+
+            ApplySelection(selectionBuffer);
+        }
+
+        private void ApplySelection(List<FoilPatternDef> selection)
+        {
+            var count = selection?.Count ?? 0;
+            if (maxItems > 0)
+            {
+                count = Mathf.Min(count, maxItems);
+            }
+
+            EnsureItemCapacity(count);
+
+            for (var i = 0; i < spawnedItems.Count; i++)
+            {
+                var item = spawnedItems[i];
+                if (item == null)
+                {
+                    continue;
+                }
+
+                if (i < count)
+                {
+                    var def = selection[i];
+                    if (generateRuntimeVariants && library != null && def != null)
+                    {
+                        var runtime = library.CreateRuntime(def, random);
+                        item.gameObject.SetActive(true);
+                        item.Present(runtime);
+                    }
+                    else
+                    {
+                        item.gameObject.SetActive(true);
+                        item.Present(def);
+                    }
+                }
+                else
+                {
+                    item.Clear();
+                    item.gameObject.SetActive(false);
+                }
+            }
+        }
+
+        private void EnsureItemCapacity(int desiredCount)
+        {
+            for (var i = spawnedItems.Count; i < desiredCount; i++)
+            {
+                var item = CreateItemInstance();
+                if (item != null)
+                {
+                    spawnedItems.Add(item);
+                }
+            }
+
+            for (var i = desiredCount; i < spawnedItems.Count; i++)
+            {
+                var item = spawnedItems[i];
+                if (item == null)
+                {
+                    continue;
+                }
+
+                item.Clear();
+                item.gameObject.SetActive(false);
+            }
+        }
+
+        private FoilPatternShowcaseItem CreateItemInstance()
+        {
+            if (itemPrefab == null)
+            {
+                return null;
+            }
+
+            var parent = contentRoot != null ? contentRoot : transform;
+            var instance = Instantiate(itemPrefab, parent);
+            instance.gameObject.SetActive(true);
+            return instance;
+        }
+
+        private void BuildPatternPool()
+        {
+            patternPool.Clear();
+            var source = library.Patterns;
+            for (var i = 0; i < source.Count; i++)
+            {
+                var def = source[i];
+                if (def == null)
+                {
+                    continue;
+                }
+
+                patternPool.Add(def);
+            }
+        }
+
+        private void EnsureContentRoot()
+        {
+            if (contentRoot != null)
+            {
+                return;
+            }
+
+            if (itemPrefab != null && itemPrefab.transform.parent != null)
+            {
+                contentRoot = itemPrefab.transform.parent;
+            }
+            else
+            {
+                contentRoot = transform;
+            }
+        }
+
+        private void EnsureRandom()
+        {
+            if (random != null)
+            {
+                return;
+            }
+
+            random = seed != 0 ? new System.Random(seed) : new System.Random(Environment.TickCount ^ GetInstanceID());
+        }
+    }
+}

--- a/Assets/GW/Scripts/UI/FoilPatternShowcaseItem.cs
+++ b/Assets/GW/Scripts/UI/FoilPatternShowcaseItem.cs
@@ -1,0 +1,141 @@
+using UnityEngine;
+using UnityEngine.UI;
+using GW.Core;
+using GW.Gameplay;
+
+namespace GW.UI
+{
+    [DisallowMultipleComponent]
+    public sealed class FoilPatternShowcaseItem : MonoBehaviour
+    {
+        [SerializeField]
+        private Image iconImage;
+
+        [SerializeField]
+        private Image tintSwatch;
+
+        [SerializeField]
+        private Text nameLabel;
+
+        [SerializeField]
+        private Text rarityLabel;
+
+        [SerializeField]
+        private Text detailLabel;
+
+        [Header("Rarity Colors")]
+        [SerializeField]
+        private Color commonColor = new Color32(201, 166, 70, 255);
+
+        [SerializeField]
+        private Color rareColor = new Color32(255, 211, 110, 255);
+
+        [SerializeField]
+        private Color epicColor = new Color32(255, 238, 163, 255);
+
+        [SerializeField]
+        private Color legendaryColor = new Color32(255, 249, 220, 255);
+
+        public void Present(FoilPatternRuntime runtime)
+        {
+            Present(runtime.Definition, runtime);
+        }
+
+        public void Present(FoilPatternDef pattern, FoilPatternRuntime? runtime = null)
+        {
+            var rarity = pattern != null ? pattern.Rarity : FoilPatternRarity.Common;
+            var rarityColor = GetRarityColor(rarity);
+            var displayName = pattern != null ? pattern.DisplayName : "Pattern";
+
+            if (iconImage != null)
+            {
+                iconImage.enabled = pattern != null && pattern.Icon != null;
+                iconImage.sprite = pattern != null ? pattern.Icon : null;
+                iconImage.color = rarityColor;
+            }
+
+            if (tintSwatch != null)
+            {
+                if (runtime.HasValue)
+                {
+                    tintSwatch.color = Color.Lerp(runtime.Value.PrimaryTint, runtime.Value.SecondaryTint, 0.5f);
+                }
+                else
+                {
+                    tintSwatch.color = rarityColor;
+                }
+            }
+
+            if (nameLabel != null)
+            {
+                nameLabel.text = displayName;
+            }
+
+            if (rarityLabel != null)
+            {
+                rarityLabel.text = rarity.ToString().ToUpperInvariant();
+                rarityLabel.color = rarityColor;
+            }
+
+            if (detailLabel != null)
+            {
+                if (pattern == null)
+                {
+                    detailLabel.text = string.Empty;
+                }
+                else
+                {
+                    var angle = pattern.LineAngle;
+                    if (runtime.HasValue)
+                    {
+                        var dir = runtime.Value.FlowDirection;
+                        angle = Mathf.Atan2(dir.y, dir.x) * Mathf.Rad2Deg;
+                    }
+
+                    detailLabel.text = $"Spec {pattern.Specular:F2} • Freq {pattern.LineFrequency:F1} • Angle {angle:F0}°";
+                }
+            }
+        }
+
+        public void Clear()
+        {
+            if (iconImage != null)
+            {
+                iconImage.enabled = false;
+                iconImage.sprite = null;
+            }
+
+            if (tintSwatch != null)
+            {
+                tintSwatch.color = Color.clear;
+            }
+
+            if (nameLabel != null)
+            {
+                nameLabel.text = string.Empty;
+            }
+
+            if (rarityLabel != null)
+            {
+                rarityLabel.text = string.Empty;
+            }
+
+            if (detailLabel != null)
+            {
+                detailLabel.text = string.Empty;
+            }
+        }
+
+        private Color GetRarityColor(FoilPatternRarity rarity)
+        {
+            return rarity switch
+            {
+                FoilPatternRarity.Common => commonColor,
+                FoilPatternRarity.Rare => rareColor,
+                FoilPatternRarity.Epic => epicColor,
+                FoilPatternRarity.Legendary => legendaryColor,
+                _ => commonColor,
+            };
+        }
+    }
+}

--- a/Assets/GW/Scripts/UI/MainMenuController.cs
+++ b/Assets/GW/Scripts/UI/MainMenuController.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using UnityEngine.SceneManagement;
+using GW.Gameplay;
 
 namespace GW.UI
 {
@@ -7,6 +8,37 @@ namespace GW.UI
     {
         [SerializeField]
         private string gameSceneName = "Game";
+
+        [Header("Foil Showcase")]
+        [SerializeField]
+        private FoilPatternShowcase patternShowcase;
+
+        [SerializeField]
+        private FoilPatternLibrary patternLibrary;
+
+        [SerializeField]
+        [Tooltip("Resource path used if no library reference is provided explicitly.")]
+        private string patternLibraryResourcePath = "FoilPatternLibrary";
+
+        [SerializeField]
+        [Tooltip("Refresh the foil pattern showcase automatically on enable.")]
+        private bool autoRefreshShowcase = true;
+
+        private void Awake()
+        {
+            if (autoRefreshShowcase)
+            {
+                RefreshPatternShowcase();
+            }
+        }
+
+        private void OnEnable()
+        {
+            if (autoRefreshShowcase)
+            {
+                RefreshPatternShowcase();
+            }
+        }
 
         public void StartCareer()
         {
@@ -17,6 +49,45 @@ namespace GW.UI
             }
 
             SceneManager.LoadScene(gameSceneName);
+        }
+
+        public void SetPatternLibrary(FoilPatternLibrary library)
+        {
+            patternLibrary = library;
+            RefreshPatternShowcase();
+        }
+
+        public void SetPatternShowcase(FoilPatternShowcase showcase)
+        {
+            patternShowcase = showcase;
+            RefreshPatternShowcase();
+        }
+
+        private void RefreshPatternShowcase()
+        {
+            if (patternShowcase == null)
+            {
+                patternShowcase = FindObjectOfType<FoilPatternShowcase>(true);
+            }
+
+            if (patternShowcase == null)
+            {
+                return;
+            }
+
+            if (patternLibrary == null && !string.IsNullOrWhiteSpace(patternLibraryResourcePath))
+            {
+                patternLibrary = Resources.Load<FoilPatternLibrary>(patternLibraryResourcePath);
+            }
+
+            if (patternLibrary != null)
+            {
+                patternShowcase.SetLibrary(patternLibrary);
+            }
+            else
+            {
+                patternShowcase.Refresh();
+            }
         }
     }
 }

--- a/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
+++ b/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
@@ -1,0 +1,276 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace GW.UI
+{
+    [ExecuteAlways]
+    [DisallowMultipleComponent]
+    [RequireComponent(typeof(Canvas))]
+    public sealed class MainMenuLayoutBootstrap : MonoBehaviour
+    {
+        [SerializeField]
+        private string titleText = "GOLDEN WRAP";
+
+        [SerializeField]
+        private string subtitleText = "Бесконечная фабрика золотой обёртки";
+
+        [SerializeField]
+        private string playButtonText = "Играть";
+
+        [SerializeField]
+        private string showcaseTitleText = "Витрина узоров";
+
+        [SerializeField]
+        private string showcaseSubtitleText = "Здесь появятся ваши любимые паттерны фольги.";
+
+        private Button cachedPlayButton;
+
+        private static readonly Color32 BackgroundColor = new Color32(14, 13, 12, 230);
+        private static readonly Color32 PanelColor = new Color32(54, 46, 36, 200);
+        private static readonly Color32 TitleColor = new Color32(0xF3, 0xE9, 0xD2, 0xFF);
+        private static readonly Color32 SubtitleColor = new Color32(0xF9, 0xF9, 0xF9, 180);
+        private static readonly Color32 ButtonNormalColor = new Color32(0xC9, 0xA6, 0x46, 0xFF);
+        private static readonly Color32 ButtonHighlightedColor = new Color32(0xFF, 0xD3, 0x6E, 0xFF);
+        private static readonly Color32 ButtonPressedColor = new Color32(0x8F, 0x7A, 0x2F, 0xFF);
+        private static readonly Color32 ButtonTextColor = new Color32(0x36, 0x2E, 0x24, 0xFF);
+
+        private void Awake()
+        {
+            Bootstrap();
+        }
+
+        private void OnEnable()
+        {
+            Bootstrap();
+        }
+
+#if UNITY_EDITOR
+        private void OnValidate()
+        {
+            Bootstrap();
+        }
+#endif
+
+        private void Bootstrap()
+        {
+            EnsureCanvasComponents();
+            EnsureEventSystem();
+            EnsureLayout();
+        }
+
+        private void EnsureCanvasComponents()
+        {
+            var canvas = GetComponent<Canvas>();
+            if (canvas == null)
+            {
+                return;
+            }
+
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+            var scaler = GetComponent<CanvasScaler>();
+            if (scaler == null)
+            {
+                scaler = gameObject.AddComponent<CanvasScaler>();
+            }
+
+            scaler.uiScaleMode = CanvasScaler.ScaleMode.ScaleWithScreenSize;
+            scaler.referenceResolution = new Vector2(1920f, 1080f);
+            scaler.screenMatchMode = CanvasScaler.ScreenMatchMode.MatchWidthOrHeight;
+            scaler.matchWidthOrHeight = 0.5f;
+
+            if (GetComponent<GraphicRaycaster>() == null)
+            {
+                gameObject.AddComponent<GraphicRaycaster>();
+            }
+        }
+
+        private void EnsureEventSystem()
+        {
+            if (FindObjectOfType<EventSystem>() != null)
+            {
+                return;
+            }
+
+            var eventSystem = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
+            var standaloneModule = eventSystem.GetComponent<StandaloneInputModule>();
+            standaloneModule.forceModuleActive = false;
+        }
+
+        private void EnsureLayout()
+        {
+            var layoutRoot = transform.Find("LayoutRoot") as RectTransform;
+            if (layoutRoot == null)
+            {
+                layoutRoot = CreateLayoutHierarchy();
+            }
+
+            if (layoutRoot == null)
+            {
+                return;
+            }
+
+            cachedPlayButton = layoutRoot.GetComponentInChildren<Button>(true);
+            ConfigurePlayButton();
+        }
+
+        private RectTransform CreateLayoutHierarchy()
+        {
+            var layoutRoot = new GameObject("LayoutRoot", typeof(RectTransform)).GetComponent<RectTransform>();
+            layoutRoot.SetParent(transform, false);
+            layoutRoot.anchorMin = Vector2.zero;
+            layoutRoot.anchorMax = Vector2.one;
+            layoutRoot.offsetMin = new Vector2(40f, 40f);
+            layoutRoot.offsetMax = new Vector2(-40f, -40f);
+
+            var background = new GameObject("Background", typeof(RectTransform), typeof(Image));
+            background.transform.SetParent(layoutRoot, false);
+            var backgroundRect = background.GetComponent<RectTransform>();
+            backgroundRect.anchorMin = Vector2.zero;
+            backgroundRect.anchorMax = Vector2.one;
+            backgroundRect.offsetMin = Vector2.zero;
+            backgroundRect.offsetMax = Vector2.zero;
+            var backgroundImage = background.GetComponent<Image>();
+            backgroundImage.color = BackgroundColor;
+            backgroundImage.raycastTarget = false;
+
+            var title = CreateText("Title", layoutRoot, titleText, 44, TextAnchor.UpperLeft, TitleColor);
+            var titleRect = title.rectTransform;
+            titleRect.anchorMin = new Vector2(0f, 1f);
+            titleRect.anchorMax = new Vector2(0.6f, 1f);
+            titleRect.pivot = new Vector2(0f, 1f);
+            titleRect.anchoredPosition = new Vector2(24f, -24f);
+
+            var subtitle = CreateText("Subtitle", layoutRoot, subtitleText, 24, TextAnchor.UpperLeft, SubtitleColor);
+            var subtitleRect = subtitle.rectTransform;
+            subtitleRect.anchorMin = new Vector2(0f, 1f);
+            subtitleRect.anchorMax = new Vector2(0.6f, 1f);
+            subtitleRect.pivot = new Vector2(0f, 1f);
+            subtitleRect.anchoredPosition = new Vector2(24f, -84f);
+
+            cachedPlayButton = CreatePlayButton(layoutRoot);
+
+            var showcase = new GameObject("ShowcasePlaceholder", typeof(RectTransform), typeof(Image));
+            showcase.transform.SetParent(layoutRoot, false);
+            var showcaseRect = showcase.GetComponent<RectTransform>();
+            showcaseRect.anchorMin = new Vector2(0.55f, 0.15f);
+            showcaseRect.anchorMax = new Vector2(0.95f, 0.85f);
+            showcaseRect.offsetMin = Vector2.zero;
+            showcaseRect.offsetMax = Vector2.zero;
+            var showcaseImage = showcase.GetComponent<Image>();
+            showcaseImage.color = PanelColor;
+            showcaseImage.raycastTarget = false;
+
+            var showcaseTitle = CreateText("ShowcaseTitle", showcase.transform, showcaseTitleText, 28, TextAnchor.UpperCenter, TitleColor);
+            var showcaseTitleRect = showcaseTitle.rectTransform;
+            showcaseTitleRect.anchorMin = new Vector2(0.1f, 0.8f);
+            showcaseTitleRect.anchorMax = new Vector2(0.9f, 0.95f);
+            showcaseTitleRect.offsetMin = Vector2.zero;
+            showcaseTitleRect.offsetMax = Vector2.zero;
+
+            var showcaseSubtitle = CreateText("ShowcaseSubtitle", showcase.transform, showcaseSubtitleText, 18, TextAnchor.MiddleCenter, SubtitleColor);
+            var showcaseSubtitleRect = showcaseSubtitle.rectTransform;
+            showcaseSubtitleRect.anchorMin = new Vector2(0.1f, 0.15f);
+            showcaseSubtitleRect.anchorMax = new Vector2(0.9f, 0.75f);
+            showcaseSubtitleRect.offsetMin = Vector2.zero;
+            showcaseSubtitleRect.offsetMax = Vector2.zero;
+
+            return layoutRoot;
+        }
+
+        private Button CreatePlayButton(Transform parent)
+        {
+            var buttonObject = new GameObject("PlayButton", typeof(RectTransform), typeof(Image), typeof(Button));
+            buttonObject.transform.SetParent(parent, false);
+            var rect = buttonObject.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0f, 0f);
+            rect.anchorMax = new Vector2(0f, 0f);
+            rect.pivot = new Vector2(0f, 0f);
+            rect.anchoredPosition = new Vector2(24f, 24f);
+            rect.sizeDelta = new Vector2(240f, 72f);
+
+            var image = buttonObject.GetComponent<Image>();
+            image.color = ButtonNormalColor;
+
+            var button = buttonObject.GetComponent<Button>();
+            button.targetGraphic = image;
+            var colors = button.colors;
+            colors.normalColor = ButtonNormalColor;
+            colors.highlightedColor = ButtonHighlightedColor;
+            colors.pressedColor = ButtonPressedColor;
+            colors.selectedColor = ButtonHighlightedColor;
+            colors.disabledColor = new Color32(80, 70, 55, 180);
+            button.colors = colors;
+
+            var label = CreateText("Label", button.transform, playButtonText, 28, TextAnchor.MiddleCenter, ButtonTextColor);
+            var labelRect = label.rectTransform;
+            labelRect.anchorMin = Vector2.zero;
+            labelRect.anchorMax = Vector2.one;
+            labelRect.offsetMin = new Vector2(16f, 12f);
+            labelRect.offsetMax = new Vector2(-16f, -12f);
+
+            return button;
+        }
+
+        private Text CreateText(string name, Transform parent, string text, int fontSize, TextAnchor alignment, Color color)
+        {
+            var go = new GameObject(name, typeof(RectTransform));
+            go.transform.SetParent(parent, false);
+            var rect = go.GetComponent<RectTransform>();
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+
+            var textComponent = go.AddComponent<Text>();
+            textComponent.text = text;
+            textComponent.fontSize = fontSize;
+            textComponent.alignment = alignment;
+            textComponent.color = color;
+            textComponent.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            textComponent.horizontalOverflow = HorizontalWrapMode.Wrap;
+            textComponent.verticalOverflow = VerticalWrapMode.Truncate;
+            textComponent.raycastTarget = false;
+            textComponent.supportRichText = false;
+
+            return textComponent;
+        }
+
+        private void ConfigurePlayButton()
+        {
+            if (cachedPlayButton == null)
+            {
+                return;
+            }
+
+            cachedPlayButton.onClick.RemoveListener(OnPlayButtonClicked);
+            cachedPlayButton.onClick.AddListener(OnPlayButtonClicked);
+
+            var label = cachedPlayButton.transform.Find("Label");
+            if (label != null && label.TryGetComponent<Text>(out var labelText))
+            {
+                labelText.text = playButtonText;
+            }
+        }
+
+        private void OnPlayButtonClicked()
+        {
+#if UNITY_EDITOR
+            if (!Application.isPlaying)
+            {
+                return;
+            }
+#endif
+            var controller = GetComponent<MainMenuController>();
+            if (controller != null)
+            {
+                controller.StartCareer();
+            }
+            else
+            {
+                Debug.LogWarning("MainMenuController component not found on the main menu root.");
+            }
+        }
+    }
+}

--- a/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs.meta
+++ b/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0eb4a922a3084219b77ef03027423bc0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add a bootstrapper that builds the main menu canvas layout with a play button and foil showcase placeholder
- configure the main menu scene with canvas scaler, graphic raycaster, and an event system for UI interaction

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d879506ca48322a071c3d1c5be5dda