### PR TITLE
Remove obsolete StandaloneInputModule configuration

### DIFF
--- a/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
+++ b/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
@@ -95,7 +95,6 @@ namespace GW.UI
 
             var eventSystem = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
             var standaloneModule = eventSystem.GetComponent<StandaloneInputModule>();
-            standaloneModule.forceModuleActive = false;
         }
 
         private void EnsureLayout()


### PR DESCRIPTION
## Summary
- stop assigning the deprecated StandaloneInputModule.forceModuleActive flag when creating the EventSystem prefab

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8835e112c8322ad91994808a2cea9