### PR TITLE
Delay editor bootstrap to avoid OnValidate SendMessage errors

### DIFF
--- a/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
+++ b/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
@@ -1,6 +1,9 @@
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 namespace GW.UI
 {
@@ -48,6 +51,24 @@ namespace GW.UI
 #if UNITY_EDITOR
         private void OnValidate()
         {
+            if (Application.isPlaying)
+            {
+                Bootstrap();
+                return;
+            }
+
+            EditorApplication.delayCall += HandleEditorDelayCall;
+        }
+
+        private void HandleEditorDelayCall()
+        {
+            EditorApplication.delayCall -= HandleEditorDelayCall;
+
+            if (this == null || Application.isPlaying)
+            {
+                return;
+            }
+
             Bootstrap();
         }
 #endif


### PR DESCRIPTION
## Summary
- guard the main menu layout bootstrap against running during edit-mode validation
- defer editor execution with delayCall so layout construction happens outside OnValidate

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68d90c0f12808322bf3eb60d6daac848