### PR TITLE
Use LegacyRuntime font for main menu text

### DIFF
--- a/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
+++ b/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
@@ -248,7 +248,7 @@ namespace GW.UI
             textComponent.fontSize = fontSize;
             textComponent.alignment = alignment;
             textComponent.color = color;
-            textComponent.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            textComponent.font = Resources.GetBuiltinResource<Font>("LegacyRuntime.ttf");
             textComponent.horizontalOverflow = HorizontalWrapMode.Wrap;
             textComponent.verticalOverflow = VerticalWrapMode.Truncate;
             textComponent.raycastTarget = false;


### PR DESCRIPTION
## Summary
- update the main menu text bootstrap to load the LegacyRuntime builtin font
- prevent runtime font loading exceptions caused by the unavailable Arial builtin font

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_e_68d91072c7648322bde08d6f55db4acb