### PR TITLE
Guard main menu layout bootstrap during validation

### DIFF
--- a/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
+++ b/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
@@ -53,10 +53,10 @@ namespace GW.UI
         {
             if (Application.isPlaying)
             {
-                Bootstrap();
                 return;
             }
 
+            EditorApplication.delayCall -= HandleEditorDelayCall;
             EditorApplication.delayCall += HandleEditorDelayCall;
         }
 


### PR DESCRIPTION
## Summary
- stop `MainMenuLayoutBootstrap` from invoking `Bootstrap` while `OnValidate` runs in play mode
- deduplicate the delayed editor callback registration used for edit-time refreshes

## Testing
- not run (Unity editor unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d91208d6dc83229cd682a469241835