### PR TITLE
Remove deprecated StandaloneInputModule configuration

### DIFF
--- a/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
+++ b/Assets/GW/Scripts/UI/MainMenuLayoutBootstrap.cs
@@ -114,8 +114,7 @@ namespace GW.UI
                 return;
             }
 
-            var eventSystem = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
-            var standaloneModule = eventSystem.GetComponent<StandaloneInputModule>();
+            _ = new GameObject("EventSystem", typeof(EventSystem), typeof(StandaloneInputModule));
         }
 
         private void EnsureLayout()


### PR DESCRIPTION
## Summary
- stop retaining a StandaloneInputModule reference when creating a fallback EventSystem, avoiding deprecated configuration

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9127c921c8322a3bbd5c4c38bf83e