### PR TITLE
Add foil pattern definitions and library

### DIFF
--- a/Assets/GW/Data/FoilPatterns/FoilPattern_CommonAurora.asset
+++ b/Assets/GW/Data/FoilPatterns/FoilPattern_CommonAurora.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e05d9e27408e1e14d9cff3753992eb09, type: 3}
+  m_Name: FoilPattern_CommonAurora
+  m_EditorClassIdentifier:
+  id: foil_common_aurora
+  displayName: "Северное сияние"
+  icon: {fileID: 21300000, guid: 0000000000000000f000000000000000, type: 0}
+  specular: 0.4
+  lineFrequency: 4.5
+  lineAngle: 12
+  embossDepth: 0.18
+  seed: 101
+  rarity: 0
+  description: "Мягкие полосы, отражающие спокойный вечерний свет."

--- a/Assets/GW/Data/FoilPatterns/FoilPattern_CommonAurora.asset.meta
+++ b/Assets/GW/Data/FoilPatterns/FoilPattern_CommonAurora.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 354fd1e05b5f4764ba223b7d1216b307
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Data/FoilPatterns/FoilPattern_EpicPrism.asset
+++ b/Assets/GW/Data/FoilPatterns/FoilPattern_EpicPrism.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e05d9e27408e1e14d9cff3753992eb09, type: 3}
+  m_Name: FoilPattern_EpicPrism
+  m_EditorClassIdentifier:
+  id: foil_epic_prism
+  displayName: "Призматический грозд"
+  icon: {fileID: 21300000, guid: 0000000000000000f000000000000000, type: 0}
+  specular: 0.72
+  lineFrequency: 9.5
+  lineAngle: -28
+  embossDepth: 0.33
+  seed: 389
+  rarity: 2
+  description: "Множественные гранёные плоскости рассыпают свет веером."

--- a/Assets/GW/Data/FoilPatterns/FoilPattern_EpicPrism.asset.meta
+++ b/Assets/GW/Data/FoilPatterns/FoilPattern_EpicPrism.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c133aa55bf684a52a8448b019ae532e2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Data/FoilPatterns/FoilPattern_LegendaryCrown.asset
+++ b/Assets/GW/Data/FoilPatterns/FoilPattern_LegendaryCrown.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e05d9e27408e1e14d9cff3753992eb09, type: 3}
+  m_Name: FoilPattern_LegendaryCrown
+  m_EditorClassIdentifier:
+  id: foil_legendary_crown
+  displayName: "Королевский венец"
+  icon: {fileID: 21300000, guid: 0000000000000000f000000000000000, type: 0}
+  specular: 0.88
+  lineFrequency: 5.75
+  lineAngle: 62
+  embossDepth: 0.41
+  seed: 587
+  rarity: 3
+  description: "Редчайший чеканный орнамент с сиянием короны."

--- a/Assets/GW/Data/FoilPatterns/FoilPattern_LegendaryCrown.asset.meta
+++ b/Assets/GW/Data/FoilPatterns/FoilPattern_LegendaryCrown.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c8ea620c5ad44676a5916c7cfb893864
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Data/FoilPatterns/FoilPattern_RareHelix.asset
+++ b/Assets/GW/Data/FoilPatterns/FoilPattern_RareHelix.asset
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e05d9e27408e1e14d9cff3753992eb09, type: 3}
+  m_Name: FoilPattern_RareHelix
+  m_EditorClassIdentifier:
+  id: foil_rare_helix
+  displayName: "Спиральная спевка"
+  icon: {fileID: 21300000, guid: 0000000000000000f000000000000000, type: 0}
+  specular: 0.55
+  lineFrequency: 7
+  lineAngle: 33
+  embossDepth: 0.24
+  seed: 214
+  rarity: 1
+  description: "Ленты изящных спиралей создают глубокие блики."

--- a/Assets/GW/Data/FoilPatterns/FoilPattern_RareHelix.asset.meta
+++ b/Assets/GW/Data/FoilPatterns/FoilPattern_RareHelix.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4453be6ce8a540bebc4f17ba4ba2ad95
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Resources/FoilPatternLibrary.asset
+++ b/Assets/GW/Resources/FoilPatternLibrary.asset
@@ -1,0 +1,144 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a8cac3883118f38499e93ef6c6dc39a5, type: 3}
+  m_Name: FoilPatternLibrary
+  m_EditorClassIdentifier:
+  patterns:
+  - {fileID: 11400000, guid: 354fd1e05b5f4764ba223b7d1216b307, type: 2}
+  - {fileID: 11400000, guid: 4453be6ce8a540bebc4f17ba4ba2ad95, type: 2}
+  - {fileID: 11400000, guid: c133aa55bf684a52a8448b019ae532e2, type: 2}
+  - {fileID: 11400000, guid: c8ea620c5ad44676a5916c7cfb893864, type: 2}
+  rarityWeights:
+  - Rarity: 0
+    Weight: 60
+  - Rarity: 1
+    Weight: 25
+  - Rarity: 2
+    Weight: 12
+  - Rarity: 3
+    Weight: 3
+  commonTintGradient:
+    serializedVersion: 2
+    key0: {r: 0.7882353, g: 0.6509804, b: 0.27450982, a: 1}
+    key1: {r: 0.6745098, g: 0.5647059, b: 0.227451, a: 1}
+    key2: {r: 0.56078434, g: 0.47843137, b: 0.18431373, a: 1}
+    key3: {r: 0, g: 0, b: 0, a: 0}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 32768
+    ctime2: 65535
+    ctime3: 0
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 65535
+    atime2: 0
+    atime3: 0
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 3
+    m_NumAlphaKeys: 2
+  rareTintGradient:
+    serializedVersion: 2
+    key0: {r: 1, g: 0.827451, b: 0.43137255, a: 1}
+    key1: {r: 0.8941177, g: 0.77254903, b: 0.3529412, a: 1}
+    key2: {r: 0.7882353, g: 0.6509804, b: 0.27450982, a: 1}
+    key3: {r: 0, g: 0, b: 0, a: 0}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 32768
+    ctime2: 65535
+    ctime3: 0
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 65535
+    atime2: 0
+    atime3: 0
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 3
+    m_NumAlphaKeys: 2
+  epicTintGradient:
+    serializedVersion: 2
+    key0: {r: 1, g: 0.93333334, b: 0.6392157, a: 1}
+    key1: {r: 0.8980393, g: 0.78431374, b: 0.45294118, a: 1}
+    key2: {r: 0.7882353, g: 0.6509804, b: 0.27450982, a: 1}
+    key3: {r: 0, g: 0, b: 0, a: 0}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 32768
+    ctime2: 65535
+    ctime3: 0
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 65535
+    atime2: 0
+    atime3: 0
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 3
+    m_NumAlphaKeys: 2
+  legendaryTintGradient:
+    serializedVersion: 2
+    key0: {r: 1, g: 0.9764706, b: 0.8627451, a: 1}
+    key1: {r: 1, g: 0.9019608, b: 0.64705884, a: 1}
+    key2: {r: 1, g: 0.827451, b: 0.43137255, a: 1}
+    key3: {r: 0, g: 0, b: 0, a: 0}
+    key4: {r: 0, g: 0, b: 0, a: 0}
+    key5: {r: 0, g: 0, b: 0, a: 0}
+    key6: {r: 0, g: 0, b: 0, a: 0}
+    key7: {r: 0, g: 0, b: 0, a: 0}
+    ctime0: 0
+    ctime1: 32768
+    ctime2: 65535
+    ctime3: 0
+    ctime4: 0
+    ctime5: 0
+    ctime6: 0
+    ctime7: 0
+    atime0: 0
+    atime1: 65535
+    atime2: 0
+    atime3: 0
+    atime4: 0
+    atime5: 0
+    atime6: 0
+    atime7: 0
+    m_Mode: 0
+    m_NumColorKeys: 3
+    m_NumAlphaKeys: 2

--- a/Assets/GW/Resources/FoilPatternLibrary.asset.meta
+++ b/Assets/GW/Resources/FoilPatternLibrary.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5bfe1b7823d244cdac03dca6168796e5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/GW/Scenes/MainMenu.unity
+++ b/Assets/GW/Scenes/MainMenu.unity
@@ -338,6 +338,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8c2e17b560d8411a90d7e4eb89c42cf2, type: 3}
   m_Name:
   m_EditorClassIdentifier:
+  gameSceneName: Game
+  patternShowcase: {fileID: 0}
+  patternLibrary: {fileID: 11400000, guid: 5bfe1b7823d244cdac03dca6168796e5, type: 2}
+  patternLibraryResourcePath: FoilPatternLibrary
+  autoRefreshShowcase: 1
 --- !u!1 &7261533302796269233
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## Summary
- add a FoilPatterns data folder with common, rare, epic, and legendary FoilPatternDef assets complete with metadata
- create a FoilPatternLibrary ScriptableObject in Resources that references the new patterns and tunes rarity weights and gradients
- link the main menu controller to the new library asset so the resource path resolves correctly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d92892dc648322b5758c84ffe67f54