### PR TITLE
Implement sprint 8 audio system

### DIFF
--- a/Assets/GW/Scripts/Core/Audio/AudioController.cs
+++ b/Assets/GW/Scripts/Core/Audio/AudioController.cs
@@ -1,0 +1,542 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace GW.Core
+{
+    /// <summary>
+    /// Centralised audio service that handles pooled SFX playback and layered music.
+    /// </summary>
+    [DisallowMultipleComponent]
+    public sealed class AudioController : MonoBehaviour
+    {
+        private const float MinPitch = 0.01f;
+
+        private static AudioController instance;
+
+        [SerializeField]
+        [Tooltip("List of short SFX cues that can be triggered by gameplay.")]
+        private List<SfxEntry> sfxEntries = new();
+
+        [SerializeField]
+        [Tooltip("Looping music layers (ambient, percussion, bliss loop, etc.).")]
+        private List<MusicLayerEntry> musicLayers = new();
+
+        [SerializeField]
+        [Tooltip("Number of one-shot AudioSources pre-created for SFX playback.")]
+        [Min(0)]
+        private int initialSfxPoolSize = 8;
+
+        [SerializeField]
+        [Tooltip("Random pitch variation range applied to SFX (min/max).")]
+        private Vector2 pitchVariation = new(0.95f, 1.05f);
+
+        private readonly Dictionary<SfxId, SfxEntry> sfxLookup = new();
+        private readonly Dictionary<MusicLayerId, MusicLayerEntry> musicLookup = new();
+        private readonly Queue<AudioSource> sfxPool = new();
+        private readonly List<SfxPlayback> activeSfx = new();
+
+        private System.Random random;
+        private bool initialised;
+
+        /// <summary>
+        /// Gets the active audio controller instance, creating one on first access if necessary.
+        /// </summary>
+        public static AudioController Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    var existing = FindObjectOfType<AudioController>();
+                    if (existing != null)
+                    {
+                        instance = existing;
+                        instance.EnsureInitialised();
+                    }
+                    else
+                    {
+                        var go = new GameObject("AudioController");
+                        instance = go.AddComponent<AudioController>();
+                    }
+                }
+
+                return instance;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if an audio controller has been initialised.
+        /// </summary>
+        public static bool HasInstance => instance != null;
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+            EnsureInitialised();
+        }
+
+        private void Update()
+        {
+            if (!initialised)
+            {
+                return;
+            }
+
+            var deltaTime = Time.unscaledDeltaTime;
+            UpdateActiveSfx(deltaTime);
+            UpdateMusicLayers(deltaTime);
+        }
+
+        private void OnDestroy()
+        {
+            if (instance == this)
+            {
+                instance = null;
+            }
+        }
+
+        private void EnsureInitialised()
+        {
+            if (initialised)
+            {
+                return;
+            }
+
+            random ??= new System.Random(Environment.TickCount);
+            BuildLookups();
+            PrewarmPool(initialSfxPoolSize);
+            InitialiseMusicSources();
+            SetMusicLayerActive(MusicLayerId.BaseAmbient, true, true);
+            initialised = true;
+        }
+
+        /// <summary>
+        /// Plays an SFX one-shot with subtle pitch variation.
+        /// </summary>
+        public void PlaySfx(SfxId id, float volumeScale = 1f)
+        {
+            if (!initialised || id == SfxId.None)
+            {
+                return;
+            }
+
+            if (!sfxLookup.TryGetValue(id, out var entry))
+            {
+                return;
+            }
+
+            var clip = entry.GetNextClip(random);
+            if (clip == null)
+            {
+                return;
+            }
+
+            var source = GetSfxSource();
+            source.clip = clip;
+            source.loop = false;
+            source.volume = Mathf.Clamp01(entry.Volume * volumeScale);
+            source.pitch = GetRandomPitch();
+            source.Play();
+
+            var playback = new SfxPlayback
+            {
+                Source = source,
+                Id = id,
+                Remaining = clip.length / Mathf.Max(MinPitch, source.pitch),
+            };
+
+            activeSfx.Add(playback);
+        }
+
+        /// <summary>
+        /// Starts or stops the percussion layer based on gameplay combo state.
+        /// </summary>
+        public void SetPercussionActive(bool active)
+        {
+            SetMusicLayerActive(MusicLayerId.Percussion, active);
+        }
+
+        /// <summary>
+        /// Signals that Bliss mode has entered its active state.
+        /// </summary>
+        public void NotifyBlissActivated()
+        {
+            PlaySfx(SfxId.BlissEnter);
+            PlaySfx(SfxId.BlissDrop);
+            SetMusicLayerActive(MusicLayerId.BlissLoop, true);
+        }
+
+        /// <summary>
+        /// Signals that Bliss mode has ended.
+        /// </summary>
+        public void NotifyBlissDeactivated()
+        {
+            PlaySfx(SfxId.BlissExit);
+            SetMusicLayerActive(MusicLayerId.BlissLoop, false);
+        }
+
+        /// <summary>
+        /// Plays an audio cue appropriate for the supplied seal grade.
+        /// </summary>
+        public void PlaySealGrade(SealGrade grade)
+        {
+            switch (grade)
+            {
+                case SealGrade.Perfect:
+                    PlaySfx(SfxId.SealPerfect);
+                    break;
+                case SealGrade.Good:
+                    PlaySfx(SfxId.SealGood);
+                    break;
+                case SealGrade.Fail:
+                    PlaySfx(SfxId.SealFail);
+                    break;
+            }
+        }
+
+        /// <summary>
+        /// Plays the milestone cue associated with the provided combo value (10/25/50).
+        /// </summary>
+        public void PlayComboMilestone(int combo)
+        {
+            switch (combo)
+            {
+                case 10:
+                    PlaySfx(SfxId.ComboMilestone10);
+                    break;
+                case 25:
+                    PlaySfx(SfxId.ComboMilestone25);
+                    break;
+                case 50:
+                    PlaySfx(SfxId.ComboMilestone50);
+                    break;
+            }
+        }
+
+        private void BuildLookups()
+        {
+            sfxLookup.Clear();
+            for (var i = 0; i < sfxEntries.Count; i++)
+            {
+                var entry = sfxEntries[i];
+                if (entry == null || entry.Id == SfxId.None)
+                {
+                    continue;
+                }
+
+                if (!sfxLookup.ContainsKey(entry.Id))
+                {
+                    entry.Reset();
+                    sfxLookup.Add(entry.Id, entry);
+                }
+            }
+
+            musicLookup.Clear();
+            for (var i = 0; i < musicLayers.Count; i++)
+            {
+                var layer = musicLayers[i];
+                if (layer == null)
+                {
+                    continue;
+                }
+
+                if (musicLookup.ContainsKey(layer.Id))
+                {
+                    continue;
+                }
+
+                musicLookup.Add(layer.Id, layer);
+            }
+        }
+
+        private void PrewarmPool(int count)
+        {
+            for (var i = 0; i < count; i++)
+            {
+                var source = CreateSfxSource($"SFX_{i:00}");
+                sfxPool.Enqueue(source);
+            }
+        }
+
+        private AudioSource GetSfxSource()
+        {
+            if (sfxPool.Count > 0)
+            {
+                var pooled = sfxPool.Dequeue();
+                pooled.clip = null;
+                pooled.loop = false;
+                pooled.volume = 1f;
+                pooled.pitch = 1f;
+                return pooled;
+            }
+
+            return CreateSfxSource($"SFX_{transform.childCount:00}");
+        }
+
+        private AudioSource CreateSfxSource(string name)
+        {
+            var source = gameObject.AddComponent<AudioSource>();
+            source.playOnAwake = false;
+            source.loop = false;
+            source.spatialBlend = 0f;
+            source.name = name;
+            return source;
+        }
+
+        private void UpdateActiveSfx(float deltaTime)
+        {
+            for (var i = activeSfx.Count - 1; i >= 0; i--)
+            {
+                var playback = activeSfx[i];
+                playback.Remaining -= deltaTime;
+                if (playback.Remaining > 0f)
+                {
+                    continue;
+                }
+
+                var source = playback.Source;
+                if (source != null)
+                {
+                    source.Stop();
+                    source.clip = null;
+                    sfxPool.Enqueue(source);
+                }
+
+                activeSfx.RemoveAt(i);
+            }
+        }
+
+        private void InitialiseMusicSources()
+        {
+            for (var i = 0; i < musicLayers.Count; i++)
+            {
+                var layer = musicLayers[i];
+                if (layer == null)
+                {
+                    continue;
+                }
+
+                if (layer.Source == null)
+                {
+                    var source = gameObject.AddComponent<AudioSource>();
+                    source.playOnAwake = false;
+                    source.loop = layer.Loop;
+                    source.spatialBlend = 0f;
+                    source.clip = layer.Clip;
+                    source.volume = 0f;
+                    layer.Source = source;
+                }
+                else
+                {
+                    layer.Source.loop = layer.Loop;
+                    layer.Source.clip = layer.Clip;
+                }
+
+                if (layer.PlayOnAwake && layer.Clip != null)
+                {
+                    layer.TargetVolume = layer.BaseVolume;
+                    layer.Source.volume = layer.BaseVolume;
+                    if (!layer.Source.isPlaying)
+                    {
+                        layer.Source.Play();
+                    }
+                }
+                else
+                {
+                    layer.TargetVolume = 0f;
+                    layer.Source.volume = 0f;
+                    if (layer.Source.isPlaying)
+                    {
+                        layer.Source.Stop();
+                    }
+                }
+            }
+        }
+
+        private void UpdateMusicLayers(float deltaTime)
+        {
+            for (var i = 0; i < musicLayers.Count; i++)
+            {
+                var layer = musicLayers[i];
+                if (layer?.Source == null)
+                {
+                    continue;
+                }
+
+                var target = Mathf.Clamp01(layer.TargetVolume);
+                var current = layer.Source.volume;
+
+                if (Mathf.Approximately(current, target))
+                {
+                    if (target <= 0f && layer.Source.isPlaying)
+                    {
+                        layer.Source.Stop();
+                    }
+
+                    continue;
+                }
+
+                var duration = target > current ? layer.FadeInSeconds : layer.FadeOutSeconds;
+                duration = Mathf.Max(0.001f, duration);
+                var step = deltaTime / duration;
+                var next = Mathf.MoveTowards(current, target, step);
+                layer.Source.volume = next;
+
+                if (target > 0f && !layer.Source.isPlaying && layer.Clip != null)
+                {
+                    layer.Source.Play();
+                }
+                else if (target <= 0f && Mathf.Approximately(next, 0f) && layer.Source.isPlaying)
+                {
+                    layer.Source.Stop();
+                }
+            }
+        }
+
+        private void SetMusicLayerActive(MusicLayerId id, bool active, bool immediate = false)
+        {
+            if (!musicLookup.TryGetValue(id, out var layer) || layer?.Source == null)
+            {
+                return;
+            }
+
+            layer.TargetVolume = active ? layer.BaseVolume : 0f;
+
+            if (active && layer.Clip != null && !layer.Source.isPlaying)
+            {
+                layer.Source.Play();
+            }
+
+            if (immediate)
+            {
+                layer.Source.volume = layer.TargetVolume;
+                if (!active)
+                {
+                    layer.Source.Stop();
+                }
+            }
+        }
+
+        private float GetRandomPitch()
+        {
+            var min = Mathf.Min(pitchVariation.x, pitchVariation.y);
+            var max = Mathf.Max(pitchVariation.x, pitchVariation.y);
+            if (Mathf.Approximately(min, max))
+            {
+                return Mathf.Clamp(min, MinPitch, 3f);
+            }
+
+            var t = (float)random.NextDouble();
+            var pitch = Mathf.Lerp(min, max, t);
+            return Mathf.Clamp(pitch, MinPitch, 3f);
+        }
+
+        [Serializable]
+        private sealed class SfxEntry
+        {
+            [SerializeField]
+            private SfxId id = SfxId.None;
+
+            [SerializeField]
+            [Range(0f, 1f)]
+            private float volume = 1f;
+
+            [SerializeField]
+            private List<AudioClip> clips = new();
+
+            [NonSerialized]
+            private int lastClip = -1;
+
+            public SfxId Id => id;
+            public float Volume => volume;
+
+            public AudioClip GetNextClip(System.Random rng)
+            {
+                if (clips == null || clips.Count == 0)
+                {
+                    return null;
+                }
+
+                if (clips.Count == 1)
+                {
+                    lastClip = 0;
+                    return clips[0];
+                }
+
+                var index = rng.Next(clips.Count);
+                if (index == lastClip)
+                {
+                    index = (index + 1) % clips.Count;
+                }
+
+                lastClip = index;
+                return clips[index];
+            }
+
+            public void Reset()
+            {
+                lastClip = -1;
+            }
+        }
+
+        [Serializable]
+        private sealed class MusicLayerEntry
+        {
+            [SerializeField]
+            private MusicLayerId id = MusicLayerId.BaseAmbient;
+
+            [SerializeField]
+            private AudioClip clip;
+
+            [SerializeField]
+            [Range(0f, 1f)]
+            private float baseVolume = 0.75f;
+
+            [SerializeField]
+            private bool loop = true;
+
+            [SerializeField]
+            private bool playOnAwake;
+
+            [SerializeField]
+            [Range(0.01f, 5f)]
+            private float fadeInSeconds = 0.5f;
+
+            [SerializeField]
+            [Range(0.01f, 5f)]
+            private float fadeOutSeconds = 0.5f;
+
+            [NonSerialized]
+            private AudioSource source;
+
+            [NonSerialized]
+            private float targetVolume;
+
+            public MusicLayerId Id => id;
+            public AudioClip Clip => clip;
+            public float BaseVolume => baseVolume;
+            public bool Loop => loop;
+            public bool PlayOnAwake => playOnAwake;
+            public float FadeInSeconds => fadeInSeconds;
+            public float FadeOutSeconds => fadeOutSeconds;
+            public AudioSource Source { get => source; set => source = value; }
+            public float TargetVolume { get => targetVolume; set => targetVolume = value; }
+        }
+
+        private sealed class SfxPlayback
+        {
+            public AudioSource Source;
+            public SfxId Id;
+            public float Remaining;
+        }
+
+    }
+}

--- a/Assets/GW/Scripts/Core/Audio/MusicLayerId.cs
+++ b/Assets/GW/Scripts/Core/Audio/MusicLayerId.cs
@@ -1,0 +1,12 @@
+namespace GW.Core
+{
+    /// <summary>
+    /// Identifiers for persistent music layers controlled by <see cref="AudioController"/>.
+    /// </summary>
+    public enum MusicLayerId
+    {
+        BaseAmbient = 0,
+        Percussion,
+        BlissLoop,
+    }
+}

--- a/Assets/GW/Scripts/Core/Audio/SfxId.cs
+++ b/Assets/GW/Scripts/Core/Audio/SfxId.cs
@@ -1,0 +1,22 @@
+using System;
+
+namespace GW.Core
+{
+    /// <summary>
+    /// Identifiers for short sound effects played through <see cref="AudioController"/>.
+    /// </summary>
+    public enum SfxId
+    {
+        None = 0,
+        SealClick,
+        SealPerfect,
+        SealGood,
+        SealFail,
+        BlissEnter,
+        BlissExit,
+        BlissDrop,
+        ComboMilestone10,
+        ComboMilestone25,
+        ComboMilestone50,
+    }
+}

--- a/Assets/GW/Scripts/Gameplay/BlissController.cs
+++ b/Assets/GW/Scripts/Gameplay/BlissController.cs
@@ -17,15 +17,6 @@ namespace GW.Gameplay
         private GameObject vfxRoot;
 
         [SerializeField]
-        private AudioSource enterAudio;
-
-        [SerializeField]
-        private AudioSource loopAudio;
-
-        [SerializeField]
-        private AudioSource exitAudio;
-
-        [SerializeField]
         private LineFocusController focusController;
 
         [Header("Bliss Settings")]
@@ -61,12 +52,6 @@ namespace GW.Gameplay
             if (vfxRoot != null)
             {
                 vfxRoot.SetActive(false);
-            }
-
-            if (loopAudio != null)
-            {
-                loopAudio.loop = true;
-                loopAudio.playOnAwake = false;
             }
 
             if (focusController == null)
@@ -157,16 +142,6 @@ namespace GW.Gameplay
                 vfxRoot.SetActive(true);
             }
 
-            if (enterAudio != null)
-            {
-                enterAudio.Play();
-            }
-
-            if (loopAudio != null)
-            {
-                loopAudio.Play();
-            }
-
             StateChanged?.Invoke(true);
         }
 
@@ -177,15 +152,10 @@ namespace GW.Gameplay
             isActive = false;
             remainingUnscaledTime = 0f;
 
-            StopAudioAndVfx();
+            StopVfx();
 
             Time.timeScale = cachedTimeScale;
             Time.fixedDeltaTime = cachedFixedDeltaTime;
-
-            if (wasActive && exitAudio != null)
-            {
-                exitAudio.Play();
-            }
 
             if (notify)
             {
@@ -208,16 +178,11 @@ namespace GW.Gameplay
             return focusController.IsLineFocused(trackedLine);
         }
 
-        private void StopAudioAndVfx()
+        private void StopVfx()
         {
             if (vfxRoot != null)
             {
                 vfxRoot.SetActive(false);
-            }
-
-            if (loopAudio != null)
-            {
-                loopAudio.Stop();
             }
         }
     }

--- a/Assets/GW/Scripts/Gameplay/GameplayAudioBridge.cs
+++ b/Assets/GW/Scripts/Gameplay/GameplayAudioBridge.cs
@@ -1,0 +1,291 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using GW.Core;
+
+namespace GW.Gameplay
+{
+    /// <summary>
+    /// Bridges gameplay events (seal grades, combos, bliss state) to the audio controller.
+    /// Ensures feedback stays punchy without scattering audio calls across multiple systems.
+    /// </summary>
+    [DisallowMultipleComponent]
+    [DefaultExecutionOrder(200)]
+    public sealed class GameplayAudioBridge : MonoBehaviour
+    {
+        private static readonly int[] ComboMilestones = { 10, 25, 50 };
+        private const int PercussionComboThreshold = 10;
+
+        [Header("Auto Binding")]
+        [SerializeField]
+        private bool autoDiscover = true;
+
+        [Header("Manual References")]
+        [SerializeField]
+        private List<ConveyorLineController> lines = new();
+
+        [SerializeField]
+        private List<BlissController> blissControllers = new();
+
+        private readonly Dictionary<ConveyorLineController, int> lineCombos = new();
+        private readonly Dictionary<ConveyorLineController, Action<int>> comboHandlers = new();
+        private readonly Dictionary<BlissController, Action<bool>> blissHandlers = new();
+        private readonly HashSet<BlissController> activeBlissControllers = new();
+
+        private void OnEnable()
+        {
+            _ = AudioController.Instance;
+            RefreshBindings();
+            SubscribeAll();
+            UpdatePercussionState();
+        }
+
+        private void OnDisable()
+        {
+            UnsubscribeAll();
+            if (AudioController.HasInstance)
+            {
+                AudioController.Instance.SetPercussionActive(false);
+
+                if (activeBlissControllers.Count > 0)
+                {
+                    AudioController.Instance.NotifyBlissDeactivated();
+                }
+            }
+
+            activeBlissControllers.Clear();
+            lineCombos.Clear();
+        }
+
+        private void RefreshBindings()
+        {
+            if (lines == null)
+            {
+                lines = new List<ConveyorLineController>();
+            }
+            else
+            {
+                lines.RemoveAll(l => l == null);
+            }
+
+            if (blissControllers == null)
+            {
+                blissControllers = new List<BlissController>();
+            }
+            else
+            {
+                blissControllers.RemoveAll(b => b == null);
+            }
+
+            if (!autoDiscover)
+            {
+                return;
+            }
+
+            var discoveredLines = FindObjectsOfType<ConveyorLineController>(true);
+            for (var i = 0; i < discoveredLines.Length; i++)
+            {
+                var line = discoveredLines[i];
+                if (line == null || lines.Contains(line))
+                {
+                    continue;
+                }
+
+                lines.Add(line);
+            }
+
+            var discoveredBliss = FindObjectsOfType<BlissController>(true);
+            for (var i = 0; i < discoveredBliss.Length; i++)
+            {
+                var controller = discoveredBliss[i];
+                if (controller == null || blissControllers.Contains(controller))
+                {
+                    continue;
+                }
+
+                blissControllers.Add(controller);
+            }
+        }
+
+        private void SubscribeAll()
+        {
+            if (lines != null)
+            {
+                for (var i = 0; i < lines.Count; i++)
+                {
+                    SubscribeLine(lines[i]);
+                }
+            }
+
+            if (blissControllers != null)
+            {
+                for (var i = 0; i < blissControllers.Count; i++)
+                {
+                    SubscribeBliss(blissControllers[i]);
+                }
+            }
+        }
+
+        private void UnsubscribeAll()
+        {
+            if (lines != null)
+            {
+                for (var i = 0; i < lines.Count; i++)
+                {
+                    UnsubscribeLine(lines[i]);
+                }
+            }
+
+            if (blissControllers != null)
+            {
+                for (var i = 0; i < blissControllers.Count; i++)
+                {
+                    UnsubscribeBliss(blissControllers[i]);
+                }
+            }
+        }
+
+        private void SubscribeLine(ConveyorLineController line)
+        {
+            if (line == null || comboHandlers.ContainsKey(line))
+            {
+                return;
+            }
+
+            line.SealResolved += HandleSealResolved;
+            Action<int> comboHandler = combo => HandleLineComboChanged(line, combo);
+            line.ComboChanged += comboHandler;
+            comboHandlers[line] = comboHandler;
+            lineCombos[line] = line.Judge?.Combo ?? 0;
+        }
+
+        private void UnsubscribeLine(ConveyorLineController line)
+        {
+            if (line == null)
+            {
+                return;
+            }
+
+            line.SealResolved -= HandleSealResolved;
+
+            if (comboHandlers.TryGetValue(line, out var handler))
+            {
+                line.ComboChanged -= handler;
+                comboHandlers.Remove(line);
+            }
+
+            lineCombos.Remove(line);
+        }
+
+        private void SubscribeBliss(BlissController controller)
+        {
+            if (controller == null || blissHandlers.ContainsKey(controller))
+            {
+                return;
+            }
+
+            Action<bool> handler = state => HandleBlissStateChanged(controller, state);
+            controller.StateChanged += handler;
+            blissHandlers[controller] = handler;
+        }
+
+        private void UnsubscribeBliss(BlissController controller)
+        {
+            if (controller == null)
+            {
+                return;
+            }
+
+            if (blissHandlers.TryGetValue(controller, out var handler))
+            {
+                controller.StateChanged -= handler;
+                blissHandlers.Remove(controller);
+            }
+
+            activeBlissControllers.Remove(controller);
+        }
+
+        private void HandleSealResolved(ConveyorLineController line, SealGrade grade)
+        {
+            if (!AudioController.HasInstance)
+            {
+                return;
+            }
+
+            AudioController.Instance.PlaySealGrade(grade);
+        }
+
+        private void HandleLineComboChanged(ConveyorLineController line, int combo)
+        {
+            if (line == null)
+            {
+                return;
+            }
+
+            var previous = lineCombos.TryGetValue(line, out var last) ? last : 0;
+            lineCombos[line] = combo;
+
+            if (AudioController.HasInstance)
+            {
+                for (var i = 0; i < ComboMilestones.Length; i++)
+                {
+                    var milestone = ComboMilestones[i];
+                    if (combo == milestone && previous < milestone)
+                    {
+                        AudioController.Instance.PlayComboMilestone(milestone);
+                        break;
+                    }
+                }
+            }
+
+            UpdatePercussionState();
+        }
+
+        private void HandleBlissStateChanged(BlissController controller, bool active)
+        {
+            if (controller == null || !AudioController.HasInstance)
+            {
+                return;
+            }
+
+            if (active)
+            {
+                if (activeBlissControllers.Add(controller) && activeBlissControllers.Count == 1)
+                {
+                    AudioController.Instance.NotifyBlissActivated();
+                }
+            }
+            else
+            {
+                if (activeBlissControllers.Remove(controller) && activeBlissControllers.Count == 0)
+                {
+                    AudioController.Instance.NotifyBlissDeactivated();
+                }
+            }
+        }
+
+        private void UpdatePercussionState()
+        {
+            if (!AudioController.HasInstance)
+            {
+                return;
+            }
+
+            var highest = 0;
+            foreach (var kvp in lineCombos)
+            {
+                if (kvp.Key == null)
+                {
+                    continue;
+                }
+
+                if (kvp.Value > highest)
+                {
+                    highest = kvp.Value;
+                }
+            }
+
+            AudioController.Instance.SetPercussionActive(highest >= PercussionComboThreshold);
+        }
+    }
+}

--- a/Assets/GW/Scripts/Gameplay/SealZone.cs
+++ b/Assets/GW/Scripts/Gameplay/SealZone.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using GW.Core;
 
 namespace GW.Gameplay
 {
@@ -171,6 +172,12 @@ namespace GW.Gameplay
 
             var signedOffset = line.CalculateOffsetFromSealPoint(targetCandy.transform.position);
             signedOffset = ApplyBlissAutoSnap(signedOffset);
+
+            if (AudioController.HasInstance)
+            {
+                AudioController.Instance.PlaySfx(SfxId.SealClick);
+            }
+
             line.ProcessSealAttempt(targetCandy, signedOffset);
         }
 


### PR DESCRIPTION
## Summary
- add a pooled AudioController with layered music support plus SfxId and MusicLayerId identifiers
- bridge conveyor gameplay events into audio cues and manage Bliss music state
- update BlissController and SealZone to drive feedback through the shared audio controller

## Testing
- not run (WebGL/Unity project)


------
https://chatgpt.com/codex/tasks/task_e_68d92e4ae82c832297b2a9e5b40643a8