### PR TITLE
Fix WebGL configurator for older Unity versions

### DIFF
--- a/Assets/GW/Editor/WebGLBuildConfigurator.cs
+++ b/Assets/GW/Editor/WebGLBuildConfigurator.cs
@@ -51,14 +51,25 @@ namespace GW.EditorTools
         private static void ConfigurePlayerSettings()
         {
             PlayerSettings.SetScriptingBackend(BuildTargetGroup.WebGL, ScriptingImplementation.IL2CPP);
-            PlayerSettings.SetApiCompatibilityLevel(BuildTargetGroup.WebGL, ApiCompatibilityLevel.NETStandard);
+            PlayerSettings.SetApiCompatibilityLevel(
+                BuildTargetGroup.WebGL,
+#if UNITY_2021_2_OR_NEWER
+                ApiCompatibilityLevel.NETStandard
+#else
+                ApiCompatibilityLevel.NET_4_6
+#endif
+            );
             PlayerSettings.SetManagedStrippingLevel(BuildTargetGroup.WebGL, ManagedStrippingLevel.Low);
             PlayerSettings.stripEngineCode = true;
             PlayerSettings.WebGL.memorySize = 384;
             PlayerSettings.WebGL.compressionFormat = WebGLCompressionFormat.Brotli;
             PlayerSettings.WebGL.exceptionSupport = WebGLExceptionSupport.ExplicitlyThrownExceptionsOnly;
             PlayerSettings.WebGL.linkerTarget = WebGLLinkerTarget.Wasm;
+#if UNITY_2021_2_OR_NEWER
+            PlayerSettings.WebGL.debugSymbolMode = WebGLDebugSymbolMode.Off;
+#else
             PlayerSettings.WebGL.debugSymbols = false;
+#endif
             PlayerSettings.defaultWebScreenWidth = 1920;
             PlayerSettings.defaultWebScreenHeight = 1080;
             PlayerSettings.defaultIsNativeResolution = true;
@@ -71,8 +82,10 @@ namespace GW.EditorTools
             EditorUserBuildSettings.development = false;
             EditorUserBuildSettings.connectProfiler = false;
             EditorUserBuildSettings.allowDebugging = false;
+#if UNITY_2021_2_OR_NEWER
             EditorUserBuildSettings.webGLCompressionFormat = WebGLCompressionFormat.Brotli;
             EditorUserBuildSettings.webGLLinkerTarget = WebGLLinkerTarget.Wasm;
+#endif
         }
     }
 }


### PR DESCRIPTION
## Summary
- fall back to the legacy .NET 4.x API compatibility level on Unity versions that do not define NETStandard
- switch to WebGL debugSymbolMode while retaining compatibility with older Unity versions
- guard newer EditorUserBuildSettings fields so the configurator compiles across Unity versions

## Testing
- not run (Unity editor environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d954b04cbc8322b24161525c1d5cb6