### PR TITLE
Replace null-coalescing assignments for older C# compatibility

### DIFF
--- a/Assets/GW/Scripts/Core/Audio/AudioController.cs
+++ b/Assets/GW/Scripts/Core/Audio/AudioController.cs
@@ -16,11 +16,11 @@ namespace GW.Core
 
         [SerializeField]
         [Tooltip("List of short SFX cues that can be triggered by gameplay.")]
-        private List<SfxEntry> sfxEntries = new();
+        private List<SfxEntry> sfxEntries = new List<SfxEntry>();
 
         [SerializeField]
         [Tooltip("Looping music layers (ambient, percussion, bliss loop, etc.).")]
-        private List<MusicLayerEntry> musicLayers = new();
+        private List<MusicLayerEntry> musicLayers = new List<MusicLayerEntry>();
 
         [SerializeField]
         [Tooltip("Number of one-shot AudioSources pre-created for SFX playback.")]
@@ -29,12 +29,12 @@ namespace GW.Core
 
         [SerializeField]
         [Tooltip("Random pitch variation range applied to SFX (min/max).")]
-        private Vector2 pitchVariation = new(0.95f, 1.05f);
+        private Vector2 pitchVariation = new Vector2(0.95f, 1.05f);
 
-        private readonly Dictionary<SfxId, SfxEntry> sfxLookup = new();
-        private readonly Dictionary<MusicLayerId, MusicLayerEntry> musicLookup = new();
-        private readonly Queue<AudioSource> sfxPool = new();
-        private readonly List<SfxPlayback> activeSfx = new();
+        private readonly Dictionary<SfxId, SfxEntry> sfxLookup = new Dictionary<SfxId, SfxEntry>();
+        private readonly Dictionary<MusicLayerId, MusicLayerEntry> musicLookup = new Dictionary<MusicLayerId, MusicLayerEntry>();
+        private readonly Queue<AudioSource> sfxPool = new Queue<AudioSource>();
+        private readonly List<SfxPlayback> activeSfx = new List<SfxPlayback>();
 
         private System.Random random;
         private bool initialised;
@@ -121,7 +121,10 @@ namespace GW.Core
                 return;
             }
 
-            random ??= new System.Random(Environment.TickCount);
+            if (random == null)
+            {
+                random = new System.Random(Environment.TickCount);
+            }
             BuildLookups();
             PrewarmPool(initialSfxPoolSize);
             InitialiseMusicSources();
@@ -530,7 +533,7 @@ namespace GW.Core
             private float volume = 1f;
 
             [SerializeField]
-            private List<AudioClip> clips = new();
+            private List<AudioClip> clips = new List<AudioClip>();
 
             [NonSerialized]
             private int lastClip = -1;

--- a/Assets/GW/Scripts/Core/SaveSystem.cs
+++ b/Assets/GW/Scripts/Core/SaveSystem.cs
@@ -130,17 +130,32 @@ namespace GW.Core
         public int version = 1;
         public int credits;
         public int bestCombo;
-        public List<string> unlockedPatterns = new();
-        public List<string> completedContracts = new();
-        public List<string> purchasedUpgrades = new();
-        public PlayerSettingsData settings = new();
+        public List<string> unlockedPatterns = new List<string>();
+        public List<string> completedContracts = new List<string>();
+        public List<string> purchasedUpgrades = new List<string>();
+        public PlayerSettingsData settings = new PlayerSettingsData();
 
         public void EnsureIntegrity()
         {
-            unlockedPatterns ??= new List<string>();
-            completedContracts ??= new List<string>();
-            purchasedUpgrades ??= new List<string>();
-            settings ??= new PlayerSettingsData();
+            if (unlockedPatterns == null)
+            {
+                unlockedPatterns = new List<string>();
+            }
+
+            if (completedContracts == null)
+            {
+                completedContracts = new List<string>();
+            }
+
+            if (purchasedUpgrades == null)
+            {
+                purchasedUpgrades = new List<string>();
+            }
+
+            if (settings == null)
+            {
+                settings = new PlayerSettingsData();
+            }
         }
     }
 

--- a/Assets/GW/Scripts/Gameplay/ContractSystem.cs
+++ b/Assets/GW/Scripts/Gameplay/ContractSystem.cs
@@ -14,7 +14,7 @@ namespace GW.Gameplay
     {
         [Header("Bindings")]
         [SerializeField]
-        private List<ConveyorLineController> lines = new();
+        private List<ConveyorLineController> lines = new List<ConveyorLineController>();
 
         [SerializeField]
         private bool autoPopulateLines = true;
@@ -24,7 +24,7 @@ namespace GW.Gameplay
 
         [Header("Contracts")]
         [SerializeField]
-        private List<ContractDef> contractLibrary = new();
+        private List<ContractDef> contractLibrary = new List<ContractDef>();
 
         [SerializeField]
         [Min(1)]
@@ -34,8 +34,8 @@ namespace GW.Gameplay
         [Min(0)]
         private int startingCredits;
 
-        private readonly List<ContractInstance> activeContracts = new();
-        private readonly HashSet<string> completedContracts = new();
+        private readonly List<ContractInstance> activeContracts = new List<ContractInstance>();
+        private readonly HashSet<string> completedContracts = new HashSet<string>();
         private int credits;
 
         public event Action<int> CreditsChanged;

--- a/Assets/GW/Scripts/Gameplay/ConveyorLineController.cs
+++ b/Assets/GW/Scripts/Gameplay/ConveyorLineController.cs
@@ -430,7 +430,10 @@ namespace GW.Gameplay
             if (rarityOverride.HasValue)
             {
                 pattern = foilPatternLibrary.GetRandomPattern(rarityOverride, patternRandom);
-                pattern ??= foilPatternLibrary.GetRandomPattern(null, patternRandom);
+                if (pattern == null)
+                {
+                    pattern = foilPatternLibrary.GetRandomPattern(null, patternRandom);
+                }
             }
             else
             {
@@ -579,7 +582,10 @@ namespace GW.Gameplay
 
         private void EnsurePatternRandom()
         {
-            patternRandom ??= new System.Random(Environment.TickCount ^ GetInstanceID());
+            if (patternRandom == null)
+            {
+                patternRandom = new System.Random(Environment.TickCount ^ GetInstanceID());
+            }
         }
     }
 }

--- a/Assets/GW/Scripts/Gameplay/GameStateController.cs
+++ b/Assets/GW/Scripts/Gameplay/GameStateController.cs
@@ -41,7 +41,7 @@ namespace GW.Gameplay
         private GameplayAudioBridge audioBridge;
 
         [SerializeField]
-        private List<ConveyorLineController> lines = new();
+        private List<ConveyorLineController> lines = new List<ConveyorLineController>();
 
         private bool initialised;
         private GamePhase phase = GamePhase.Booting;

--- a/Assets/GW/Scripts/Gameplay/GameplayAudioBridge.cs
+++ b/Assets/GW/Scripts/Gameplay/GameplayAudioBridge.cs
@@ -22,15 +22,15 @@ namespace GW.Gameplay
 
         [Header("Manual References")]
         [SerializeField]
-        private List<ConveyorLineController> lines = new();
+        private List<ConveyorLineController> lines = new List<ConveyorLineController>();
 
         [SerializeField]
-        private List<BlissController> blissControllers = new();
+        private List<BlissController> blissControllers = new List<BlissController>();
 
-        private readonly Dictionary<ConveyorLineController, int> lineCombos = new();
-        private readonly Dictionary<ConveyorLineController, Action<int>> comboHandlers = new();
-        private readonly Dictionary<BlissController, Action<bool>> blissHandlers = new();
-        private readonly HashSet<BlissController> activeBlissControllers = new();
+        private readonly Dictionary<ConveyorLineController, int> lineCombos = new Dictionary<ConveyorLineController, int>();
+        private readonly Dictionary<ConveyorLineController, Action<int>> comboHandlers = new Dictionary<ConveyorLineController, Action<int>>();
+        private readonly Dictionary<BlissController, Action<bool>> blissHandlers = new Dictionary<BlissController, Action<bool>>();
+        private readonly HashSet<BlissController> activeBlissControllers = new HashSet<BlissController>();
 
         private void OnEnable()
         {

--- a/Assets/GW/Scripts/Gameplay/LineFocusController.cs
+++ b/Assets/GW/Scripts/Gameplay/LineFocusController.cs
@@ -38,7 +38,7 @@ namespace GW.Gameplay
 
         [Header("Line Binding")]
         [SerializeField]
-        private List<ConveyorLineController> lines = new();
+        private List<ConveyorLineController> lines = new List<ConveyorLineController>();
 
         [SerializeField]
         private bool autoPopulateLines = true;

--- a/Assets/GW/Scripts/Gameplay/SealZone.cs
+++ b/Assets/GW/Scripts/Gameplay/SealZone.cs
@@ -18,7 +18,7 @@ namespace GW.Gameplay
         [SerializeField]
         private LineFocusController focusController;
 
-        private readonly List<CandyActor> candiesInZone = new();
+        private readonly List<CandyActor> candiesInZone = new List<CandyActor>();
         private Collider2D triggerCollider;
 
         private void Awake()

--- a/Assets/GW/Scripts/Gameplay/UpgradeNode.cs
+++ b/Assets/GW/Scripts/Gameplay/UpgradeNode.cs
@@ -33,7 +33,7 @@ namespace GW.Gameplay
         private UpgradeNode prerequisite;
 
         [SerializeField]
-        private List<UpgradeEffectDefinition> effects = new();
+        private List<UpgradeEffectDefinition> effects = new List<UpgradeEffectDefinition>();
 
         public string Id => string.IsNullOrWhiteSpace(id) ? title : id;
         public string Title => title;

--- a/Assets/GW/Scripts/Gameplay/UpgradeSystem.cs
+++ b/Assets/GW/Scripts/Gameplay/UpgradeSystem.cs
@@ -14,7 +14,7 @@ namespace GW.Gameplay
         private ContractSystem contractSystem;
 
         [SerializeField]
-        private List<ConveyorLineController> lines = new();
+        private List<ConveyorLineController> lines = new List<ConveyorLineController>();
 
         [SerializeField]
         private bool autoPopulateLines = true;
@@ -24,7 +24,7 @@ namespace GW.Gameplay
 
         [Header("Library")]
         [SerializeField]
-        private List<UpgradeNode> upgradeNodes = new();
+        private List<UpgradeNode> upgradeNodes = new List<UpgradeNode>();
 
         [SerializeField]
         private bool autoPopulateFromResources = true;
@@ -32,8 +32,8 @@ namespace GW.Gameplay
         [SerializeField]
         private string resourcesPath = "GW/Upgrades";
 
-        private readonly HashSet<string> purchasedNodeIds = new();
-        private readonly Dictionary<string, UpgradeNode> nodeLookup = new();
+        private readonly HashSet<string> purchasedNodeIds = new HashSet<string>();
+        private readonly Dictionary<string, UpgradeNode> nodeLookup = new Dictionary<string, UpgradeNode>();
 
         public event Action<UpgradeNode> UpgradePurchased;
         public event Action StateChanged;

--- a/Assets/GW/Scripts/UI/ContractsPanel.cs
+++ b/Assets/GW/Scripts/UI/ContractsPanel.cs
@@ -8,7 +8,7 @@ namespace GW.UI
     public sealed class ContractsPanel : MonoBehaviour
     {
         [SerializeField]
-        private List<ContractItemView> contractSlots = new();
+        private List<ContractItemView> contractSlots = new List<ContractItemView>();
 
         private ContractSystem system;
 

--- a/Assets/GW/Scripts/UI/SettingsPanel.cs
+++ b/Assets/GW/Scripts/UI/SettingsPanel.cs
@@ -43,7 +43,7 @@ namespace GW.UI
         private Dropdown languageDropdown;
 
         [SerializeField]
-        private List<string> languageCodes = new() { "en", "ru" };
+        private List<string> languageCodes = new List<string> { "en", "ru" };
 
         private bool suppressCallbacks;
 

--- a/Assets/GW/Scripts/UI/UpgradePanel.cs
+++ b/Assets/GW/Scripts/UI/UpgradePanel.cs
@@ -15,7 +15,7 @@ namespace GW.UI
         private string creditsFormat = "Credits: {0:N0}";
 
         [SerializeField]
-        private List<UpgradeNodeView> nodeViews = new();
+        private List<UpgradeNodeView> nodeViews = new List<UpgradeNodeView>();
 
         private UpgradeSystem system;
         private bool subscribed;


### PR DESCRIPTION
## Summary
- replace null-coalescing assignment operators in conveyor line, audio, and save system scripts with explicit null checks
- ensure runtime components compile under pre-C# 8 Unity versions so Line A and SealZone scripts stay attached

## Testing
- not run (Unity editor unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d9934c42f88322bc946c4b6cb57f0c