### PR TITLE
Fix localization service initialization syntax

### DIFF
--- a/Assets/GW/Scripts/Core/LocalizationService.cs
+++ b/Assets/GW/Scripts/Core/LocalizationService.cs
@@ -11,9 +11,9 @@ namespace GW.Core
     public static class LocalizationService
     {
         private const string ResourceRoot = "GW/Localization";
-        private static readonly Dictionary<string, string> entries = new(StringComparer.OrdinalIgnoreCase);
+        private static readonly Dictionary<string, string> entries = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private static readonly string[] defaultLanguages = { "en", "ru" };
-        private static readonly ReadOnlyCollection<string> supportedLanguages = new(defaultLanguages);
+        private static readonly ReadOnlyCollection<string> supportedLanguages = new ReadOnlyCollection<string>(defaultLanguages);
 
         private static string currentLanguage = "en";
         private static bool initialised;


### PR DESCRIPTION
## Summary
- replace target-typed `new` expressions in `LocalizationService` with explicit type constructors for compatibility with the C# 8 compiler

## Testing
- not run (editor-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d9a2b52d7883228f458d26a47391ba