### PR TITLE
Implement playable candy line gameplay skeleton

### DIFF
--- a/Assets/Scenes/SampleScene.unity
+++ b/Assets/Scenes/SampleScene.unity
@@ -206,3 +206,915 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &110000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 110000001}
+  m_Layer: 0
+  m_Name: SealZone
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &110000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 110000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &120000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 120000001}
+  - component: {fileID: 120000002}
+  m_Layer: 0
+  m_Name: GameController
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &120000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 120000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &120000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 120000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 426a09c85e0b476fbda2c467677044e0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  balance: {fileID: 0}
+  sealZone: {fileID: 110000001}
+  lanes:
+  - {fileID: 130000002}
+  - {fileID: 140000002}
+  - {fileID: 150000002}
+  scoreText: {fileID: 161000003}
+  comboText: {fileID: 162000003}
+  multiplierText: {fileID: 163000003}
+  blissText: {fileID: 164000003}
+  creditsText: {fileID: 165000003}
+  wasteText: {fileID: 166000003}
+  laneText: {fileID: 167000003}
+  windowText: {fileID: 168000003}
+  enableLaneBAtStart: 0
+  enableLaneCAtStart: 0
+--- !u!1 &130000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 130000001}
+  - component: {fileID: 130000002}
+  m_Layer: 0
+  m_Name: Lane A
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &130000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 130000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1.2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &130000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 130000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b4dbb60a0d14b8da48617b01b2a8434, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  laneLabel: A
+  laneColor: {r: 1, g: 0.7372549, b: 0.20392157, a: 1}
+  startActive: 1
+  laneHeightOffset: 0
+  laneDepth: 0
+  spawnLeadUnits: 6.5
+  despawnLeadUnits: 6.5
+  candyHeightUnits: 0.7
+--- !u!1 &140000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 140000001}
+  - component: {fileID: 140000002}
+  m_Layer: 0
+  m_Name: Lane B
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &140000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 140000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &140000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 140000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b4dbb60a0d14b8da48617b01b2a8434, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  laneLabel: B
+  laneColor: {r: 0.40392157, g: 0.7294118, b: 1, a: 1}
+  startActive: 0
+  laneHeightOffset: 0
+  laneDepth: 0
+  spawnLeadUnits: 6.5
+  despawnLeadUnits: 6.5
+  candyHeightUnits: 0.7
+--- !u!1 &150000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 150000001}
+  - component: {fileID: 150000002}
+  m_Layer: 0
+  m_Name: Lane C
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &150000001
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 150000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -1.2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &150000002
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 150000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5b4dbb60a0d14b8da48617b01b2a8434, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  laneLabel: C
+  laneColor: {r: 0.69803923, g: 0.4, b: 1, a: 1}
+  startActive: 0
+  laneHeightOffset: 0
+  laneDepth: 0
+  spawnLeadUnits: 6.5
+  despawnLeadUnits: 6.5
+  candyHeightUnits: 0.7
+--- !u!1 &160000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 160000001}
+  - component: {fileID: 160000002}
+  - component: {fileID: 160000003}
+  - component: {fileID: 160000004}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &160000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 160000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 161000001}
+  - {fileID: 162000001}
+  - {fileID: 163000001}
+  - {fileID: 164000001}
+  - {fileID: 165000001}
+  - {fileID: 166000001}
+  - {fileID: 167000001}
+  - {fileID: 168000001}
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!223 &160000002
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 160000000}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 0
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 100
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 25
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!114 &160000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 160000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 1
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 1920, y: 1080}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!114 &160000004
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 160000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &161000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 161000001}
+  - component: {fileID: 161000002}
+  - component: {fileID: 161000003}
+  m_Layer: 5
+  m_Name: ScoreText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &161000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 161000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 160000001}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 120, y: -40}
+  m_SizeDelta: {x: 300, y: 40}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &161000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 161000000}
+  m_CullTransparentMesh: 0
+--- !u!114 &161000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 161000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 28
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Score: 0
+--- !u!1 &162000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 162000001}
+  - component: {fileID: 162000002}
+  - component: {fileID: 162000003}
+  m_Layer: 5
+  m_Name: ComboText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &162000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 160000001}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 120, y: -80}
+  m_SizeDelta: {x: 300, y: 40}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &162000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162000000}
+  m_CullTransparentMesh: 0
+--- !u!114 &162000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 162000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Combo: 0
+--- !u!1 &163000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 163000001}
+  - component: {fileID: 163000002}
+  - component: {fileID: 163000003}
+  m_Layer: 5
+  m_Name: MultiplierText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &163000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 163000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 160000001}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 120, y: -120}
+  m_SizeDelta: {x: 300, y: 40}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &163000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 163000000}
+  m_CullTransparentMesh: 0
+--- !u!114 &163000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 163000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Multiplier: x1.0
+--- !u!1 &164000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 164000001}
+  - component: {fileID: 164000002}
+  - component: {fileID: 164000003}
+  m_Layer: 5
+  m_Name: BlissText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &164000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 164000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 160000001}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 120, y: -160}
+  m_SizeDelta: {x: 360, y: 40}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &164000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 164000000}
+  m_CullTransparentMesh: 0
+--- !u!114 &164000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 164000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Bliss: 0%
+--- !u!1 &165000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 165000001}
+  - component: {fileID: 165000002}
+  - component: {fileID: 165000003}
+  m_Layer: 5
+  m_Name: CreditsText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &165000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 165000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 160000001}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 120, y: -200}
+  m_SizeDelta: {x: 300, y: 40}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &165000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 165000000}
+  m_CullTransparentMesh: 0
+--- !u!114 &165000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 165000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Credits: 0
+--- !u!1 &166000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 166000001}
+  - component: {fileID: 166000002}
+  - component: {fileID: 166000003}
+  m_Layer: 5
+  m_Name: WasteText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &166000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 166000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 160000001}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 120, y: -240}
+  m_SizeDelta: {x: 300, y: 40}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &166000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 166000000}
+  m_CullTransparentMesh: 0
+--- !u!114 &166000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 166000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Waste: 0
+--- !u!1 &167000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 167000001}
+  - component: {fileID: 167000002}
+  - component: {fileID: 167000003}
+  m_Layer: 5
+  m_Name: LaneText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &167000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 167000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 160000001}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 120, y: -280}
+  m_SizeDelta: {x: 300, y: 40}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &167000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 167000000}
+  m_CullTransparentMesh: 0
+--- !u!114 &167000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 167000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Lane: 1
+--- !u!1 &168000000
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 168000001}
+  - component: {fileID: 168000002}
+  - component: {fileID: 168000003}
+  m_Layer: 5
+  m_Name: WindowText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &168000001
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 168000000}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 160000001}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 120, y: -320}
+  m_SizeDelta: {x: 360, y: 40}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &168000002
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 168000000}
+  m_CullTransparentMesh: 0
+--- !u!114 &168000003
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 168000000}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0000000000000000e000000000000000, type: 0}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 24
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Perfect Window: 12px

--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 16518e0b49974413a7b8472190c895c6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/CandyLaneController.cs
+++ b/Assets/Scripts/CandyLaneController.cs
@@ -1,0 +1,370 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace BlissSeal
+{
+    public enum SealRating
+    {
+        None,
+        Fail,
+        Good,
+        Perfect
+    }
+
+    public struct SealOutcome
+    {
+        public CandyLaneController lane;
+        public SealRating rating;
+        public float offsetPx;
+        public bool wasAuto;
+        public bool hadCandy;
+    }
+
+    [Serializable]
+    public class LaneState
+    {
+        public float calibrationBonusPx;
+        public float calibrationTimer;
+        public float laneSwapTimer;
+    }
+
+    internal class CandyInstance
+    {
+        public Transform transform;
+        public Renderer renderer;
+        public float positionX;
+    }
+
+    public class CandyLaneController : MonoBehaviour
+    {
+        [Header("Lane settings")]
+        [SerializeField] private string laneLabel = "A";
+        [SerializeField] private Color laneColor = Color.white;
+        [SerializeField] private bool startActive = true;
+
+        [Header("Visual layout")]
+        [SerializeField] private float laneHeightOffset = 0f;
+        [SerializeField] private float laneDepth = 0f;
+        [SerializeField] private float spawnLeadUnits = 6.5f;
+        [SerializeField] private float despawnLeadUnits = 6.5f;
+        [SerializeField] private float candyHeightUnits = 0.7f;
+
+        private readonly List<CandyInstance> _candies = new List<CandyInstance>();
+        private readonly LaneState _state = new LaneState();
+
+        private GameController _controller;
+        private GameBalance _balance;
+        private LaneSpeedConfig _speedConfig;
+        private Vector3 _zonePosition;
+
+        private float _currentSpeedPx;
+        private float _timeSinceSpeedIncrease;
+        private float _jitterTimer;
+        private float _jitterPercent;
+        private float _spawnTimer;
+        private bool _isActive;
+
+        private float _candyWidthUnits;
+
+        public string LaneLabel => laneLabel;
+        public bool IsActive => _isActive;
+        public LaneState State => _state;
+        public float CurrentSpeedPx => _currentSpeedPx * (1f + _jitterPercent);
+
+        public event Action<SealOutcome> OnAutoOutcome;
+
+        public void Initialize(GameController controller, GameBalance balance, LaneSpeedConfig config, Vector3 zonePosition)
+        {
+            _controller = controller;
+            _balance = balance;
+            _speedConfig = config.Clone();
+            _zonePosition = zonePosition;
+            _currentSpeedPx = _speedConfig.startSpeedPxPerSecond;
+            _candyWidthUnits = _balance.PixelsToUnits(220f);
+            _isActive = startActive;
+
+            ScheduleNextJitter();
+        }
+
+        public void ResetLane()
+        {
+            foreach (var candy in _candies)
+            {
+                if (candy?.transform)
+                {
+                    Destroy(candy.transform.gameObject);
+                }
+            }
+            _candies.Clear();
+            _state.calibrationBonusPx = 0f;
+            _state.calibrationTimer = 0f;
+            _state.laneSwapTimer = 0f;
+            _currentSpeedPx = _speedConfig.startSpeedPxPerSecond;
+            _timeSinceSpeedIncrease = 0f;
+            _jitterTimer = 0f;
+            _spawnTimer = 0f;
+            ScheduleNextJitter();
+        }
+
+        public void SetActive(bool active)
+        {
+            _isActive = active;
+        }
+
+        public void NotifyLaneSwap()
+        {
+            _state.laneSwapTimer = Mathf.Max(_state.laneSwapTimer, _controller.Balance.multiLane.laneSwapBonusDurationSeconds);
+        }
+
+        public void ApplyCalibrationBonus()
+        {
+            var economy = _controller.Balance.economy;
+            _state.calibrationBonusPx = Mathf.Min(_state.calibrationBonusPx + economy.calibrationWindowBonusPx, economy.calibrationWindowMaxStackPx);
+            _state.calibrationTimer = Mathf.Max(_state.calibrationTimer, economy.calibrationDurationSeconds);
+        }
+
+        public float GetCurrentPerfectWindowPx(float baseWindowPx)
+        {
+            float bonus = _state.calibrationBonusPx;
+            if (_state.laneSwapTimer > 0f)
+            {
+                bonus += _controller.Balance.multiLane.laneSwapPerfectBonusPx;
+            }
+            return baseWindowPx + bonus;
+        }
+
+        private float GetSpawnInterval(float speedPx)
+        {
+            return _controller.Balance.spawn.gapPx / Mathf.Max(1f, speedPx);
+        }
+
+        private void ScheduleNextJitter()
+        {
+            _jitterTimer = UnityEngine.Random.Range(_speedConfig.jitterIntervalMinSeconds, _speedConfig.jitterIntervalMaxSeconds);
+            _jitterPercent = UnityEngine.Random.Range(-_speedConfig.jitterPercent, _speedConfig.jitterPercent);
+        }
+
+        private Vector3 GetSpawnPosition()
+        {
+            float y = transform.position.y + laneHeightOffset;
+            float z = transform.position.z + laneDepth;
+            float x = _zonePosition.x - spawnLeadUnits;
+            return new Vector3(x, y, z);
+        }
+
+        private Vector3 GetDespawnPosition()
+        {
+            float y = transform.position.y + laneHeightOffset;
+            float z = transform.position.z + laneDepth;
+            float x = _zonePosition.x + despawnLeadUnits;
+            return new Vector3(x, y, z);
+        }
+
+        private void SpawnCandy()
+        {
+            if (_candies.Count >= _controller.Balance.spawn.maxPoolSize)
+            {
+                return;
+            }
+
+            var go = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            go.name = $"Candy_{laneLabel}_{_candies.Count}";
+            go.transform.SetParent(transform);
+            go.transform.localScale = new Vector3(_candyWidthUnits, candyHeightUnits, 1f);
+            go.transform.position = GetSpawnPosition();
+            var renderer = go.GetComponent<Renderer>();
+            renderer.sharedMaterial = new Material(renderer.sharedMaterial)
+            {
+                color = laneColor
+            };
+            var instance = new CandyInstance
+            {
+                transform = go.transform,
+                renderer = renderer,
+                positionX = go.transform.position.x
+            };
+            if (go.TryGetComponent<MeshCollider>(out var collider))
+            {
+                Destroy(collider);
+            }
+            _candies.Add(instance);
+        }
+
+        private void DespawnCandy(int index)
+        {
+            var candy = _candies[index];
+            if (candy?.transform)
+            {
+                Destroy(candy.transform.gameObject);
+            }
+            _candies.RemoveAt(index);
+        }
+
+        private void DespawnCandy(CandyInstance candy)
+        {
+            if (candy == null)
+            {
+                return;
+            }
+
+            if (candy.transform)
+            {
+                Destroy(candy.transform.gameObject);
+            }
+            _candies.Remove(candy);
+        }
+
+        private void UpdateCandies(float deltaTime, float perfectWindowPx, float goodWindowPx)
+        {
+            for (int i = _candies.Count - 1; i >= 0; i--)
+            {
+                var candy = _candies[i];
+                if (candy == null)
+                {
+                    _candies.RemoveAt(i);
+                    continue;
+                }
+
+                var targetSpeedUnits = CurrentSpeedPx / _controller.Balance.pixelsPerUnit;
+                candy.positionX += targetSpeedUnits * deltaTime;
+                var position = candy.transform.position;
+                position.x = candy.positionX;
+                candy.transform.position = position;
+
+                var offsetPx = (candy.positionX - _zonePosition.x) * _controller.Balance.pixelsPerUnit;
+                if (offsetPx >= goodWindowPx)
+                {
+                    DespawnCandy(i);
+                    OnAutoOutcome?.Invoke(new SealOutcome
+                    {
+                        lane = this,
+                        rating = SealRating.Fail,
+                        offsetPx = offsetPx,
+                        wasAuto = true,
+                        hadCandy = true
+                    });
+                }
+            }
+        }
+
+        private void UpdateSpeed(float deltaTime)
+        {
+            _timeSinceSpeedIncrease += deltaTime;
+            if (_currentSpeedPx < _speedConfig.speedCapPxPerSecond && _timeSinceSpeedIncrease >= _speedConfig.increaseIntervalSeconds)
+            {
+                _currentSpeedPx = Mathf.Min(_speedConfig.speedCapPxPerSecond, _currentSpeedPx + _speedConfig.speedIncreasePerInterval);
+                _timeSinceSpeedIncrease = 0f;
+            }
+        }
+
+        private void UpdateBonuses(float deltaTime)
+        {
+            if (_state.calibrationTimer > 0f)
+            {
+                _state.calibrationTimer -= deltaTime;
+                if (_state.calibrationTimer <= 0f)
+                {
+                    _state.calibrationTimer = 0f;
+                    _state.calibrationBonusPx = 0f;
+                }
+            }
+
+            if (_state.laneSwapTimer > 0f)
+            {
+                _state.laneSwapTimer -= deltaTime;
+                if (_state.laneSwapTimer < 0f)
+                {
+                    _state.laneSwapTimer = 0f;
+                }
+            }
+        }
+
+        public void Tick(float deltaTime, float basePerfectWindowPx, float goodWindowPx)
+        {
+            if (!_isActive)
+            {
+                return;
+            }
+
+            UpdateSpeed(deltaTime);
+            UpdateBonuses(deltaTime);
+
+            _jitterTimer -= deltaTime;
+            if (_jitterTimer <= 0f)
+            {
+                ScheduleNextJitter();
+            }
+
+            var spawnInterval = GetSpawnInterval(CurrentSpeedPx);
+            _spawnTimer += deltaTime;
+            if (_spawnTimer >= spawnInterval)
+            {
+                _spawnTimer -= spawnInterval;
+                SpawnCandy();
+            }
+
+            UpdateCandies(deltaTime, GetCurrentPerfectWindowPx(basePerfectWindowPx), goodWindowPx);
+        }
+
+        public SealOutcome TrySealCandy(float basePerfectWindowPx, float goodWindowPx, bool blissActive)
+        {
+            if (!_isActive)
+            {
+                return new SealOutcome { lane = this, rating = SealRating.None, hadCandy = false };
+            }
+
+            if (_candies.Count == 0)
+            {
+                return new SealOutcome { lane = this, rating = SealRating.None, hadCandy = false };
+            }
+
+            var candy = _candies[0];
+            if (candy == null || candy.transform == null)
+            {
+                _candies.RemoveAt(0);
+                return new SealOutcome { lane = this, rating = SealRating.None, hadCandy = false };
+            }
+
+            float offsetPx = (candy.transform.position.x - _zonePosition.x) * _controller.Balance.pixelsPerUnit;
+            float effectiveOffsetPx = offsetPx;
+
+            if (blissActive)
+            {
+                var autoSnap = _controller.Balance.accuracy.blissAutoSnapPercent;
+                float snap = Mathf.Min(Mathf.Abs(effectiveOffsetPx), GetCurrentPerfectWindowPx(basePerfectWindowPx) * autoSnap);
+                effectiveOffsetPx -= Mathf.Sign(effectiveOffsetPx) * snap;
+            }
+
+            var perfectWindow = GetCurrentPerfectWindowPx(basePerfectWindowPx);
+            var goodWindow = goodWindowPx;
+            var speedPx = Mathf.Abs(CurrentSpeedPx);
+            var coyoteDistancePx = speedPx * _controller.Balance.accuracy.coyoteTimeSeconds;
+
+            SealRating rating;
+            if (Mathf.Abs(effectiveOffsetPx) <= perfectWindow || Mathf.Abs(offsetPx) <= coyoteDistancePx)
+            {
+                rating = SealRating.Perfect;
+            }
+            else if (Mathf.Abs(effectiveOffsetPx) <= goodWindow)
+            {
+                rating = SealRating.Good;
+            }
+            else
+            {
+                rating = SealRating.Fail;
+            }
+
+            DespawnCandy(candy);
+
+            return new SealOutcome
+            {
+                lane = this,
+                rating = rating,
+                offsetPx = offsetPx,
+                wasAuto = false,
+                hadCandy = true
+            };
+        }
+    }
+}

--- a/Assets/Scripts/CandyLaneController.cs.meta
+++ b/Assets/Scripts/CandyLaneController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b4dbb60a0d14b8da48617b01b2a8434
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameBalance.cs
+++ b/Assets/Scripts/GameBalance.cs
@@ -1,0 +1,215 @@
+using System;
+using UnityEngine;
+
+namespace BlissSeal
+{
+    [Serializable]
+    public class AccuracyConfig
+    {
+        [Header("Windows (px @1080p)")]
+        [Tooltip("PERFECT window width in pixels. Shrinks over time until it reaches the minimum value.")]
+        public float perfectWindowPx = 12f;
+        public float perfectWindowMinPx = 9f;
+        public float perfectWindowMaxPx = 18f;
+        [Tooltip("How often the PERFECT window shrinks by 1px.")]
+        public float shrinkIntervalSeconds = 90f;
+
+        [Tooltip("GOOD window width in pixels.")]
+        public float goodWindowPx = 28f;
+        public float goodWindowMinPx = 22f;
+        public float goodWindowMaxPx = 34f;
+
+        [Header("Input forgiveness")]
+        [Tooltip("Coyote time for clicks in seconds.")]
+        public float coyoteTimeSeconds = 0.045f;
+        public float coyoteTimeMinSeconds = 0.03f;
+        public float coyoteTimeMaxSeconds = 0.06f;
+
+        [Tooltip("Additional auto snap percent applied when Bliss is active.")]
+        [Range(0f, 1f)] public float blissAutoSnapPercent = 0.22f;
+        public float blissAutoSnapMinPercent = 0.10f;
+        public float blissAutoSnapMaxPercent = 0.35f;
+    }
+
+    [Serializable]
+    public class LaneSpeedConfig
+    {
+        [Tooltip("Starting speed of the lane in px/s.")]
+        public float startSpeedPxPerSecond = 240f;
+        [Tooltip("Maximum speed in px/s.")]
+        public float speedCapPxPerSecond = 360f;
+        [Tooltip("Speed gain per interval in px/s.")]
+        public float speedIncreasePerInterval = 16f;
+        [Tooltip("Time between speed increases in seconds.")]
+        public float increaseIntervalSeconds = 25f;
+        [Tooltip("Jitter percent applied to the speed (0.025 = 2.5%)")]
+        public float jitterPercent = 0.025f;
+        public float jitterPercentMin = 0f;
+        public float jitterPercentMax = 0.04f;
+        [Tooltip("Minimum interval for jitter refresh.")]
+        public float jitterIntervalMinSeconds = 1.2f;
+        [Tooltip("Maximum interval for jitter refresh.")]
+        public float jitterIntervalMaxSeconds = 1.8f;
+
+        public LaneSpeedConfig Clone()
+        {
+            return (LaneSpeedConfig)MemberwiseClone();
+        }
+    }
+
+    [Serializable]
+    public class SpawnConfig
+    {
+        [Tooltip("Visual gap between candies in pixels.")]
+        public float gapPx = 340f;
+        public float gapMinPx = 300f;
+        public float gapMaxPx = 400f;
+        [Tooltip("Maximum simultaneous spawned candies per lane.")]
+        public int maxPoolSize = 20;
+    }
+
+    [Serializable]
+    public class ComboConfig
+    {
+        [Tooltip("Number of PERFECT hits required to increase the multiplier.")]
+        public int comboStep = 8;
+        public int comboStepMin = 6;
+        public int comboStepMax = 12;
+        [Tooltip("Base multiplier value.")]
+        public float baseMultiplier = 1f;
+        [Tooltip("How much the multiplier increases when reaching the combo step.")]
+        public float multiplierStep = 0.5f;
+        [Tooltip("Maximum multiplier value.")]
+        public float maxMultiplier = 6f;
+    }
+
+    [Serializable]
+    public class ScoreConfig
+    {
+        [Tooltip("Score gained for a PERFECT hit (before multiplier).")]
+        public int perfectScore = 25;
+        [Tooltip("Score gained for a GOOD hit (before multiplier).")]
+        public int goodScore = 12;
+        [Tooltip("Score penalty for FAIL.")]
+        public int failPenalty = -5;
+    }
+
+    [Serializable]
+    public class EconomyConfig
+    {
+        public int perfectCredits = 2;
+        public int goodCredits = 1;
+        public int failWaste = 1;
+        [Tooltip("Waste cost of a quick calibration.")]
+        public int calibrationWasteCost = 8;
+        [Tooltip("Duration of the calibration buff in seconds.")]
+        public float calibrationDurationSeconds = 30f;
+        [Tooltip("Perfect window bonus (px) per calibration.")]
+        public float calibrationWindowBonusPx = 2f;
+        [Tooltip("Maximum stack of calibration bonus (px).")]
+        public float calibrationWindowMaxStackPx = 4f;
+    }
+
+    [Serializable]
+    public class BlissConfig
+    {
+        public float perfectGainPercent = 9f;
+        public float goodGainPercent = 3f;
+        public float failLossPercent = 15f;
+        [Tooltip("Percent penalty to gain if Bliss was triggered recently.")]
+        public float antiSpamPenaltyPercent = 30f;
+        [Tooltip("Cooldown window for anti spam logic in seconds.")]
+        public float antiSpamWindowSeconds = 20f;
+
+        [Header("Activation")]
+        public float activationThresholdPercent = 100f;
+        public float durationSeconds = 4.8f;
+        public float durationMinSeconds = 4f;
+        public float durationMaxSeconds = 6f;
+        public float cooldownSeconds = 10f;
+        public float cooldownMinSeconds = 8f;
+        public float cooldownMaxSeconds = 14f;
+        public float timeScale = 0.72f;
+        [Tooltip("Duration reduction applied on every third activation within 60 seconds.")]
+        public float durationPenaltyPerStreak = 0.3f;
+        [Tooltip("Window to count Bliss activations for penalty.")]
+        public float activationStreakWindowSeconds = 60f;
+    }
+
+    [Serializable]
+    public class MultiLaneConfig
+    {
+        [Tooltip("Bliss gain penalty when two lanes are active (0.15 = 15%).")]
+        public float twoLaneBlissPenalty = 0.15f;
+        [Tooltip("Bliss gain penalty when three lanes are active (0.25 = 25%).")]
+        public float threeLaneBlissPenalty = 0.25f;
+        [Tooltip("Bonus window applied on lane swap (px).")]
+        public float laneSwapPerfectBonusPx = 1f;
+        [Tooltip("Duration of the lane swap bonus in seconds.")]
+        public float laneSwapBonusDurationSeconds = 2f;
+    }
+
+    [Serializable]
+    public class SessionProgressionConfig
+    {
+        public float laneBUnlockTimeSeconds = 300f;
+        public float laneCUnlockTimeSeconds = 480f;
+    }
+
+    [CreateAssetMenu(fileName = "GameBalance", menuName = "BlissSeal/Game Balance", order = 0)]
+    public class GameBalance : ScriptableObject
+    {
+        public float pixelsPerUnit = 108f;
+        public AccuracyConfig accuracy = new AccuracyConfig();
+        public SpawnConfig spawn = new SpawnConfig();
+        public ComboConfig combo = new ComboConfig();
+        public ScoreConfig score = new ScoreConfig();
+        public EconomyConfig economy = new EconomyConfig();
+        public BlissConfig bliss = new BlissConfig();
+        public MultiLaneConfig multiLane = new MultiLaneConfig();
+        public SessionProgressionConfig progression = new SessionProgressionConfig();
+
+        [Header("Lane Speeds")]
+        public LaneSpeedConfig laneA = new LaneSpeedConfig();
+        public LaneSpeedConfig laneB = new LaneSpeedConfig
+        {
+            startSpeedPxPerSecond = 270f,
+            speedCapPxPerSecond = 400f,
+            speedIncreasePerInterval = 16f,
+            increaseIntervalSeconds = 25f,
+            jitterPercent = 0.025f,
+            jitterPercentMin = 0f,
+            jitterPercentMax = 0.04f,
+            jitterIntervalMinSeconds = 1.2f,
+            jitterIntervalMaxSeconds = 1.8f
+        };
+        public LaneSpeedConfig laneC = new LaneSpeedConfig
+        {
+            startSpeedPxPerSecond = 300f,
+            speedCapPxPerSecond = 440f,
+            speedIncreasePerInterval = 16f,
+            increaseIntervalSeconds = 25f,
+            jitterPercent = 0.025f,
+            jitterPercentMin = 0f,
+            jitterPercentMax = 0.04f,
+            jitterIntervalMinSeconds = 1.2f,
+            jitterIntervalMaxSeconds = 1.8f
+        };
+
+        public float PixelsToUnits(float px)
+        {
+            return px / Mathf.Max(0.0001f, pixelsPerUnit);
+        }
+
+        public float UnitsToPixels(float units)
+        {
+            return units * pixelsPerUnit;
+        }
+
+        public static GameBalance CreateDefault()
+        {
+            var balance = CreateInstance<GameBalance>();
+            return balance;
+        }
+    }
+}

--- a/Assets/Scripts/GameBalance.cs.meta
+++ b/Assets/Scripts/GameBalance.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ebdff226b57a4d64852622c57586e249
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GameController.cs
+++ b/Assets/Scripts/GameController.cs
@@ -1,0 +1,506 @@
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace BlissSeal
+{
+    public class GameController : MonoBehaviour
+    {
+        [Header("Core references")]
+        [SerializeField] private GameBalance balance;
+        [SerializeField] private Transform sealZone;
+        [SerializeField] private List<CandyLaneController> lanes = new List<CandyLaneController>();
+
+        [Header("UI")]
+        [SerializeField] private Text scoreText;
+        [SerializeField] private Text comboText;
+        [SerializeField] private Text multiplierText;
+        [SerializeField] private Text blissText;
+        [SerializeField] private Text creditsText;
+        [SerializeField] private Text wasteText;
+        [SerializeField] private Text laneText;
+        [SerializeField] private Text windowText;
+
+        [Header("Gameplay state")] 
+        [SerializeField] private bool enableLaneBAtStart;
+        [SerializeField] private bool enableLaneCAtStart;
+        [Header("Seal zone visual")]
+        [SerializeField] private bool createSealZoneVisual = true;
+        [SerializeField] private Color sealZoneColor = new Color(1f, 1f, 1f, 0.2f);
+        [SerializeField] private float sealZoneHeightUnits = 6f;
+
+        private int _score;
+        private int _credits;
+        private int _waste;
+        private int _combo;
+        private int _comboProgress;
+        private float _multiplier;
+        private float _bliss;
+        private float _blissCooldown;
+        private float _blissTimer;
+        private bool _blissActive;
+        private readonly List<float> _blissActivationHistory = new List<float>();
+
+        private float _elapsedActiveTime;
+        private float _lastBlissActivationTime = -999f;
+        private int _activeLaneIndex = -1;
+        private float _currentPerfectWindowPx;
+        private GameObject _sealZoneVisual;
+
+        public GameBalance Balance => balance != null ? balance : GameBalance.CreateDefault();
+        public bool IsBlissActive => _blissActive;
+
+        private void Awake()
+        {
+            if (balance == null)
+            {
+                balance = GameBalance.CreateDefault();
+            }
+
+            _multiplier = balance.combo.baseMultiplier;
+            _currentPerfectWindowPx = balance.accuracy.perfectWindowPx;
+
+            for (int i = 0; i < lanes.Count; i++)
+            {
+                var lane = lanes[i];
+                if (lane == null)
+                {
+                    continue;
+                }
+
+                var config = balance.laneA;
+                if (i == 1)
+                {
+                    config = balance.laneB;
+                }
+                else if (i == 2)
+                {
+                    config = balance.laneC;
+                }
+
+                var zonePosition = sealZone != null ? sealZone.position : Vector3.zero;
+                lane.Initialize(this, balance, config, zonePosition);
+                lane.OnAutoOutcome += HandleSealOutcome;
+                lane.SetActive(i == 0 || (i == 1 && enableLaneBAtStart) || (i == 2 && enableLaneCAtStart));
+            }
+
+            SetActiveLane(0);
+            if (sealZone != null && createSealZoneVisual)
+            {
+                CreateSealZoneVisual();
+            }
+            UpdateUI();
+        }
+
+        private void OnDestroy()
+        {
+            foreach (var lane in lanes)
+            {
+                if (lane != null)
+                {
+                    lane.OnAutoOutcome -= HandleSealOutcome;
+                }
+            }
+        }
+
+        private void Update()
+        {
+            var dt = Time.deltaTime;
+            var laneDelta = _blissActive ? dt * balance.bliss.timeScale : dt;
+
+            UpdatePerfectWindow(dt);
+            UpdateBliss(dt);
+            UpdateLaneUnlocks();
+            UpdateSealZoneVisual();
+
+            bool anyActive = false;
+            foreach (var lane in lanes)
+            {
+                if (lane != null && lane.IsActive)
+                {
+                    lane.Tick(laneDelta, _currentPerfectWindowPx, balance.accuracy.goodWindowPx);
+                    anyActive = true;
+                }
+            }
+
+            if (anyActive)
+            {
+                _elapsedActiveTime += dt;
+            }
+
+            HandleInput();
+            UpdateUI();
+        }
+
+        private void HandleInput()
+        {
+            if (Input.GetMouseButtonDown(0))
+            {
+                TrySealActiveLane();
+            }
+
+            if (Input.GetKeyDown(KeyCode.Alpha1))
+            {
+                SetActiveLane(0);
+            }
+            else if (Input.GetKeyDown(KeyCode.Alpha2))
+            {
+                SetActiveLane(1);
+            }
+            else if (Input.GetKeyDown(KeyCode.Alpha3))
+            {
+                SetActiveLane(2);
+            }
+
+            if (Input.GetKeyDown(KeyCode.Space))
+            {
+                ActivateBliss();
+            }
+
+            if (Input.GetKeyDown(KeyCode.C))
+            {
+                TryQuickCalibration();
+            }
+        }
+
+        private void TrySealActiveLane()
+        {
+            if (_activeLaneIndex < 0 || _activeLaneIndex >= lanes.Count)
+            {
+                return;
+            }
+
+            var lane = lanes[_activeLaneIndex];
+            if (lane == null)
+            {
+                return;
+            }
+
+            var outcome = lane.TrySealCandy(_currentPerfectWindowPx, balance.accuracy.goodWindowPx, _blissActive);
+            HandleSealOutcome(outcome);
+        }
+
+        private void CreateSealZoneVisual()
+        {
+            _sealZoneVisual = GameObject.CreatePrimitive(PrimitiveType.Quad);
+            _sealZoneVisual.name = "SealZoneVisual";
+            _sealZoneVisual.transform.SetParent(sealZone, false);
+            _sealZoneVisual.transform.localPosition = Vector3.zero;
+            var renderer = _sealZoneVisual.GetComponent<Renderer>();
+            var material = new Material(renderer.sharedMaterial)
+            {
+                color = sealZoneColor
+            };
+            renderer.sharedMaterial = material;
+            if (_sealZoneVisual.TryGetComponent<MeshCollider>(out var collider))
+            {
+                Destroy(collider);
+            }
+
+            UpdateSealZoneVisual();
+        }
+
+        private void UpdateSealZoneVisual()
+        {
+            if (_sealZoneVisual == null)
+            {
+                return;
+            }
+
+            float widthUnits = balance.PixelsToUnits(_currentPerfectWindowPx * 2f);
+            float heightUnits = Mathf.Max(0.5f, sealZoneHeightUnits);
+            _sealZoneVisual.transform.localScale = new Vector3(widthUnits, heightUnits, 1f);
+        }
+
+        private void TryQuickCalibration()
+        {
+            var lane = GetActiveLane();
+            if (lane == null)
+            {
+                return;
+            }
+
+            var economy = balance.economy;
+            if (_waste < economy.calibrationWasteCost)
+            {
+                return;
+            }
+
+            _waste -= economy.calibrationWasteCost;
+            lane.ApplyCalibrationBonus();
+        }
+
+        private CandyLaneController GetActiveLane()
+        {
+            if (_activeLaneIndex < 0 || _activeLaneIndex >= lanes.Count)
+            {
+                return null;
+            }
+
+            var lane = lanes[_activeLaneIndex];
+            if (lane == null || !lane.IsActive)
+            {
+                return null;
+            }
+
+            return lane;
+        }
+
+        private void UpdatePerfectWindow(float dt)
+        {
+            var accuracy = balance.accuracy;
+            if (accuracy.shrinkIntervalSeconds <= 0f)
+            {
+                _currentPerfectWindowPx = accuracy.perfectWindowPx;
+                return;
+            }
+
+            var shrinkSteps = Mathf.FloorToInt(_elapsedActiveTime / accuracy.shrinkIntervalSeconds);
+            var target = Mathf.Max(accuracy.perfectWindowMinPx, accuracy.perfectWindowPx - shrinkSteps);
+            _currentPerfectWindowPx = Mathf.Clamp(target, accuracy.perfectWindowMinPx, accuracy.perfectWindowMaxPx);
+        }
+
+        private void UpdateBliss(float dt)
+        {
+            if (_blissActive)
+            {
+                _blissTimer -= dt;
+                if (_blissTimer <= 0f)
+                {
+                    _blissTimer = 0f;
+                    _blissActive = false;
+                    _bliss = 0f;
+                    _blissCooldown = balance.bliss.cooldownSeconds;
+                }
+            }
+            else if (_blissCooldown > 0f)
+            {
+                _blissCooldown -= dt;
+                if (_blissCooldown < 0f)
+                {
+                    _blissCooldown = 0f;
+                }
+            }
+        }
+
+        private void ActivateBliss()
+        {
+            if (_blissActive)
+            {
+                return;
+            }
+
+            if (_bliss < balance.bliss.activationThresholdPercent)
+            {
+                return;
+            }
+
+            if (_blissCooldown > 0f)
+            {
+                return;
+            }
+
+            _blissActive = true;
+            _bliss = 0f;
+            _blissTimer = CalculateBlissDuration();
+            _lastBlissActivationTime = Time.time;
+            _blissActivationHistory.Add(Time.time);
+        }
+
+        private float CalculateBlissDuration()
+        {
+            var bliss = balance.bliss;
+            float duration = bliss.durationSeconds;
+            float now = Time.time;
+
+            for (int i = _blissActivationHistory.Count - 1; i >= 0; i--)
+            {
+                if (now - _blissActivationHistory[i] > bliss.activationStreakWindowSeconds)
+                {
+                    _blissActivationHistory.RemoveAt(i);
+                }
+            }
+
+            int streakCount = _blissActivationHistory.Count + 1;
+            int penalties = streakCount / 3;
+            duration -= penalties * bliss.durationPenaltyPerStreak;
+            return Mathf.Clamp(duration, bliss.durationMinSeconds, bliss.durationMaxSeconds);
+        }
+
+        private void UpdateLaneUnlocks()
+        {
+            float time = Time.timeSinceLevelLoad;
+            if (lanes.Count > 1 && lanes[1] != null && !lanes[1].IsActive && time >= balance.progression.laneBUnlockTimeSeconds)
+            {
+                lanes[1].SetActive(true);
+            }
+
+            if (lanes.Count > 2 && lanes[2] != null && !lanes[2].IsActive && time >= balance.progression.laneCUnlockTimeSeconds)
+            {
+                lanes[2].SetActive(true);
+            }
+        }
+
+        private void HandleSealOutcome(SealOutcome outcome)
+        {
+            if (!outcome.hadCandy)
+            {
+                return;
+            }
+
+            switch (outcome.rating)
+            {
+                case SealRating.Perfect:
+                    ApplyPerfectResult(outcome);
+                    break;
+                case SealRating.Good:
+                    ApplyGoodResult();
+                    break;
+                case SealRating.Fail:
+                    ApplyFailResult();
+                    break;
+            }
+        }
+
+        private void ApplyPerfectResult(SealOutcome outcome)
+        {
+            _combo++;
+            _comboProgress++;
+            int scoreDelta = Mathf.RoundToInt(balance.score.perfectScore * _multiplier);
+            if (_blissActive)
+            {
+                scoreDelta *= 2;
+            }
+            _score += scoreDelta;
+            _credits += balance.economy.perfectCredits;
+
+            if (_comboProgress >= balance.combo.comboStep)
+            {
+                _comboProgress = 0;
+                _multiplier = Mathf.Min(balance.combo.maxMultiplier, _multiplier + balance.combo.multiplierStep);
+            }
+
+            GainBliss(balance.bliss.perfectGainPercent);
+        }
+
+        private void ApplyGoodResult()
+        {
+            int scoreDelta = Mathf.RoundToInt(balance.score.goodScore * _multiplier);
+            if (_blissActive)
+            {
+                scoreDelta *= 2;
+            }
+            _score += scoreDelta;
+            _credits += balance.economy.goodCredits;
+            GainBliss(balance.bliss.goodGainPercent);
+        }
+
+        private void ApplyFailResult()
+        {
+            _combo = 0;
+            _comboProgress = 0;
+            _multiplier = Mathf.Max(balance.combo.baseMultiplier, _multiplier - balance.combo.multiplierStep);
+            _score += balance.score.failPenalty;
+            _waste += balance.economy.failWaste;
+            GainBliss(-balance.bliss.failLossPercent);
+        }
+
+        private void GainBliss(float amount)
+        {
+            float modifier = 1f;
+            if (amount > 0f)
+            {
+                int activeCount = 0;
+                foreach (var lane in lanes)
+                {
+                    if (lane != null && lane.IsActive)
+                    {
+                        activeCount++;
+                    }
+                }
+
+                if (activeCount == 2)
+                {
+                    modifier -= balance.multiLane.twoLaneBlissPenalty;
+                }
+                else if (activeCount >= 3)
+                {
+                    modifier -= balance.multiLane.threeLaneBlissPenalty;
+                }
+
+                if (_lastBlissActivationTime > 0f && Time.time - _lastBlissActivationTime <= balance.bliss.antiSpamWindowSeconds)
+                {
+                    modifier -= balance.bliss.antiSpamPenaltyPercent / 100f;
+                }
+            }
+
+            _bliss = Mathf.Clamp(_bliss + amount * modifier, 0f, 100f);
+        }
+
+        private void SetActiveLane(int index)
+        {
+            if (index < 0 || index >= lanes.Count)
+            {
+                return;
+            }
+
+            var lane = lanes[index];
+            if (lane == null || !lane.IsActive)
+            {
+                return;
+            }
+
+            if (_activeLaneIndex == index)
+            {
+                return;
+            }
+
+            _activeLaneIndex = index;
+            lane.NotifyLaneSwap();
+        }
+
+        private void UpdateUI()
+        {
+            if (scoreText != null)
+            {
+                scoreText.text = $"Score: {_score}";
+            }
+
+            if (comboText != null)
+            {
+                comboText.text = $"Combo: {_combo}";
+            }
+
+            if (multiplierText != null)
+            {
+                multiplierText.text = $"Multiplier: x{_multiplier:F1}";
+            }
+
+            if (blissText != null)
+            {
+                string status = _blissActive ? "ACTIVE" : _blissCooldown > 0f ? $"CD {_blissCooldown:F1}s" : "Ready";
+                blissText.text = $"Bliss: {_bliss:F1}% ({status})";
+            }
+
+            if (creditsText != null)
+            {
+                creditsText.text = $"Credits: {_credits}";
+            }
+
+            if (wasteText != null)
+            {
+                wasteText.text = $"Waste: {_waste}";
+            }
+
+            if (laneText != null)
+            {
+                laneText.text = $"Lane: {(_activeLaneIndex + 1)}";
+            }
+
+            if (windowText != null)
+            {
+                windowText.text = $"Perfect Window: {_currentPerfectWindowPx:F1}px";
+            }
+        }
+    }
+}

--- a/Assets/Scripts/GameController.cs.meta
+++ b/Assets/Scripts/GameController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 426a09c85e0b476fbda2c467677044e0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- add configurable balance definitions for speeds, scoring, bliss, and economy
- implement candy lane controller logic with spawning, movement, accuracy grading, and auto-fail handling
- implement central game controller for input, scoring, bliss flow, lane switching, and quick calibration support
- update SampleScene with seal zone, three conveyor lanes, and HUD bindings for score, bliss, credits, waste, and windows

## Testing
- not run (unity editor not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d9ac9c9a7c8322a612e1812a87eb7c